### PR TITLE
patch: Add option to force HTTPs in Superset for OAuth

### DIFF
--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -636,6 +636,13 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
                 self.superset_app.wsgi_app, **self.config["PROXY_FIX_CONFIG"]
             )
 
+        # This is Pinterest custom code, the envoy https forwarding
+        # becomes http internally and it breaks HTTPs requirement for OAuth
+        if self.config['ENABLE_HTTPS_OVERRIDE']:
+            self.superset_app.wsgi_app = ForceHttps(  # type: ignore
+                self.superset_app.wsgi_app
+            )
+
         if self.config["ENABLE_CHUNK_ENCODING"]:
 
             class ChunkedEncodingFix:  # pylint: disable=too-few-public-methods
@@ -719,3 +726,15 @@ class SupersetIndexView(IndexView):
     @expose("/")
     def index(self) -> FlaskResponse:
         return redirect("/superset/welcome/")
+
+class ForceHttps(object):
+    """
+    wrapper class forces the html schema to be "https"
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        environ['wsgi.url_scheme'] = 'https'
+        return self.app(environ, start_response)


### PR DESCRIPTION
### SUMMARY
This is a Pinterest specific change. Basically the proxy system we use would convert https to http in devapps or prod. It doesn't forward any header that is useful. So we had to force the url_for to return https in order for oauth to work ( the auth system enforces https redirect_uri only)   