### PR TITLE
fix: use proxyauth for presto

### DIFF
--- a/superset/db_engine_specs/presto.py
+++ b/superset/db_engine_specs/presto.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from distutils.version import StrictVersion
 from typing import Any, cast, Dict, List, Optional, Pattern, Tuple, TYPE_CHECKING, Union
 from urllib import parse
+from requests.auth import HTTPBasicAuth, HTTPProxyAuth
 
 import pandas as pd
 import simplejson as json
@@ -131,6 +132,23 @@ def get_children(column: Dict[str, str]) -> List[Dict[str, str]]:
     raise Exception(f"Unknown type {type_}!")
 
 
+# from: https://stackoverflow.com/questions/9026016/python-requests-library-combine-httpproxyauth-with-httpbasicauth
+class HTTPBasicAndProxyAuth:
+    def __init__(self, basic_up, proxy_up):
+        # basic_up is a tuple with username, password
+        self.basic_auth = HTTPBasicAuth(*basic_up)
+        # proxy_up is a tuple with proxy username, password
+        self.proxy_auth = HTTPProxyAuth(*proxy_up)
+
+    def __call__(self, r):
+        # this emulates what basicauth and proxyauth do in their __call__()
+        # first add r.headers['Authorization']
+        r = self.basic_auth(r)
+        # then add r.headers['Proxy-Authorization']
+        r = self.proxy_auth(r)
+        # and return the request, as the auth object should do
+        return r
+
 class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-methods
     engine = "presto"
     engine_name = "Presto"
@@ -231,7 +249,15 @@ class PrestoEngineSpec(BaseEngineSpec):  # pylint: disable=too-many-public-metho
         # auth=LDAP|KERBEROS
         # Set principal_username=$effective_username
         if backend_name == "presto" and username is not None:
-            connect_args["principal_username"] = username
+            # This is Pinterest custom code that passes the proxy user
+            # via a custom HTTPProxyAuth header
+            connect_args["requests_kwargs"] = {
+                "auth": HTTPBasicAndProxyAuth(
+                    (connect_args['username'], connect_args['password']),
+                    (username, "no pass")
+                )
+            }
+            del connect_args['password']
 
     @classmethod
     def get_table_names(


### PR DESCRIPTION
Note the standard Pyhive way is to pass HTTPBasicAuth (service_user, service_password) and proxied user name `X-Presto-User` as proxy user.
I think the way we are using it is not standard, but it does work for many Querybook's use cases.

Here is the PR in pyhive that implements presto impersonation, we should eventually revert this PR to this.
https://github.com/dropbox/PyHive/pull/309