### PR TITLE
feat: add dashboard cache strategy to read cache warmup schedule from dashboard's json_metadata

### DIFF
--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -132,6 +132,9 @@ class DashboardJSONMetadataSchema(Schema):
     # used for v0 import/export
     import_time = fields.Integer()
     remote_id = fields.Integer()
+    # used to configure dashboard_metadata cache strategy
+    # (will be deprecated once TAGGING_SYSTEM feature is complete)
+    cache_warmup_schedule = fields.Str(allow_none=True)
 
 
 class UserSchema(Schema):

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -75,12 +75,13 @@ def get_form_data(
 def get_url(chart: Slice, extra_filters: Optional[Dict[str, Any]] = None) -> str:
     """Return external URL for warming up a given chart/table cache."""
     with app.test_request_context():
+        public_url = app.config.get("SUPERSET_PUBLIC_URL")
         baseurl = (
             "{SUPERSET_WEBSERVER_PROTOCOL}://"
             "{SUPERSET_WEBSERVER_ADDRESS}:"
             "{SUPERSET_WEBSERVER_PORT}".format(**app.config)
         )
-        return f"{baseurl}{chart.get_explore_url(overrides=extra_filters)}"
+        return f"{public_url or baseurl}{chart.get_explore_url(overrides=extra_filters)}"
 
 
 class Strategy:  # pylint: disable=too-few-public-methods

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -250,7 +250,51 @@ class DashboardTagsStrategy(Strategy):  # pylint: disable=too-few-public-methods
         return urls
 
 
-strategies = [DummyStrategy, TopNDashboardsStrategy, DashboardTagsStrategy]
+class DashboardMetadataStrategy(Strategy):  # pylint: disable=too-few-public-methods
+    """
+    Warm up charts in dashboards with json_metadata field containing matching
+    `cache_warmup_schedule` value
+
+    Note: This strategy can be deprecated once TAGGING_SYSTEM is a completed production feature.
+    Then, we can use DashboardTagsStrategy in place of this strategy.
+
+        CELERYBEAT_SCHEDULE = {
+            'cache-warmup-hourly': {
+                'task': 'cache-warmup',
+                'schedule': crontab(minute=1, hour='*'),  # @hourly
+                'kwargs': {
+                    'strategy_name': 'dashboard_metadata',
+                    'schedule': 'hourly',
+                },
+            },
+        }
+    """
+    name = "dashboard_metadata"
+
+    def __init__(self, schedule: str) -> None:
+        super().__init__()
+        self.schedule = schedule  # "hourly" or "daily"
+
+    def get_urls(self) -> List[str]:
+        urls = []
+        session = db.create_scoped_session()
+
+        # add dashboards that have cache warmup configured
+        cache_configured_dashboards = (
+            session.query(Dashboard)
+            .filter(Dashboard.json_metadata.like(f'%"cache_warmup_schedule"%'))
+            .all()
+        )
+        cache_configured_dashboards = [dashboard for dashboard in cache_configured_dashboards if json.loads(
+            dashboard.json_metadata).get("cache_warmup_schedule") == self.schedule]
+        for dashboard in cache_configured_dashboards:
+            for chart in dashboard.slices:
+                urls.append(get_url(chart))
+        return urls
+
+
+strategies = [DummyStrategy, TopNDashboardsStrategy,
+              DashboardTagsStrategy, DashboardMetadataStrategy]
 
 
 @celery_app.task(name="cache-warmup")


### PR DESCRIPTION
 ### SUMMARY
* Adding a cache strategy that warms up the cache for dashboards with "cache_warmup_schedule" key present in their json_metadata
* Note: this cache strategy can be deprecated once the TAGGING_SYSTEM is a completed production feature. Then, we can use `DashboardTagsStrategy` to determine which dashboards to warm up

### TESTING INSTRUCTIONS
Add a celery beat schedule such as the following to the app's celery config:
```
'cache-warmup-hourly': {
    'task': 'cache-warmup',
    'schedule': crontab(minute=1, hour='*'), 
    'kwargs': {
        'strategy_name': 'dashboard_metadata',
        'schedule': 'hourly',
    },
},
```

Then add "cache_warmup_schedule" key to a dashboard's json_metadata with value "hourly" and view logs to test that cache warmup is successful
