### PR TITLE
fix(swagger): Add swagger.html template to override FAB swagger template

### DIFF
--- a/superset/templates/superset/fab_overrides/swagger.html
+++ b/superset/templates/superset/fab_overrides/swagger.html
@@ -1,0 +1,31 @@
+<!-- Copied from
+    https://github.com/dpgaspar/Flask-AppBuilder/blob/3000c40d5b7f4d0c2cd3529299ae62e35e481d2c/flask_appbuilder/templates/appbuilder/swagger/swagger.html,
+    & updated to directly serve swagger-ui-bundle.js
+-->
+{% extends "appbuilder/base.html" %}
+
+{% block head_css %}
+{{ super() }}
+<link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css">
+<link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
+{% endblock %}
+
+{% block content %}
+<div id="swagger-ui">
+</div>
+<script src="{{ assets_prefix }}/static/assets/stylesheets/swagger/swagger-ui-bundle.js"></script>
+<!-- `SwaggerUIBundle` is now available on the page -->
+<script>
+
+    const ui = SwaggerUIBundle({
+        url: '{{openapi_uri}}',
+        dom_id: '#swagger-ui',
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout"
+
+    })
+</script>
+{% endblock %}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Add swagger.html template, copied from [FAB github project](https://github.com/dpgaspar/Flask-AppBuilder/blob/3000c40d5b7f4d0c2cd3529299ae62e35e481d2c/flask_appbuilder/templates/appbuilder/swagger/swagger.html) to override FAB's swagger template
* Allows us to serve `swagger-ui-bundle.js` directly when the following is added to the config file:
```
FAB_API_SWAGGER_TEMPLATE = "superset/fab_overrides/swagger.html"
```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
