### PR TITLE
fix: Update cache strategy to use cache timeouts

### DIFF
--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -272,9 +272,13 @@ class DashboardMetadataStrategy(Strategy):  # pylint: disable=too-few-public-met
     """
     name = "dashboard_metadata"
 
+    HOURLY_CACHE_TIMEOUT = 3600
+    DAILY_CACHE_TIMEOUT = 86400
+
     def __init__(self, schedule: str) -> None:
         super().__init__()
         self.schedule = schedule  # "hourly" or "daily"
+        self.cache_timeout = self.DAILY_CACHE_TIMEOUT if schedule == "daily" else self.HOURLY_CACHE_TIMEOUT
 
     def get_urls(self) -> List[str]:
         urls = []
@@ -290,7 +294,8 @@ class DashboardMetadataStrategy(Strategy):  # pylint: disable=too-few-public-met
             dashboard.json_metadata).get("cache_warmup_schedule") == self.schedule]
         for dashboard in cache_configured_dashboards:
             for chart in dashboard.slices:
-                urls.append(get_url(chart))
+                urls.append(get_url(chart, extra_filters={
+                            "cache_timeout": self.cache_timeout}))
         return urls
 
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Pass cache timeout along with charts loaded in cache warmup jobs
* Allows us to ensure charts in daily warmup jobs are cached for at least a day

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
