### PR TITLE
Add pinterest links to top menu

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -1326,7 +1326,7 @@ ADVANCED_DATA_TYPES: Dict[str, AdvancedDataType] = {
     "port": internet_port,
 }
 
-PINTEREST_MENU_ITEMS = None
+PINTEREST_MENU_ITEMS: List[Dict[str, str]] = None
 
 
 # -------------------------------------------------------------------

--- a/superset/config.py
+++ b/superset/config.py
@@ -1326,6 +1326,8 @@ ADVANCED_DATA_TYPES: Dict[str, AdvancedDataType] = {
     "port": internet_port,
 }
 
+PINTEREST_MENU_ITEMS = None
+
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -363,6 +363,19 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
         )
         appbuilder.add_separator("Data")
 
+        if self.config["PINTEREST_MENU_ITEMS"]:
+            for menu_item in self.config["PINTEREST_MENU_ITEMS"]:
+                appbuilder.add_link(
+                    menu_item["name"],
+                    label=__(menu_item["name"]),
+                    href=menu_item["href"],
+                    icon=menu_item["icon"],
+                    category="Pinterest",
+                    category_label=__("Pinterest"),
+                    category_icon=menu_item["icon"],
+                )
+            appbuilder.add_separator("Pinterest")
+
         appbuilder.add_api(LogRestApi)
         appbuilder.add_view(
             LogModelView,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Relevant Pinterest links can be added to the Superset UI via "PINTEREST_MENU_ITEMS" config variable

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="665" alt="Screenshot 2023-02-24 at 11 46 05 AM" src="https://user-images.githubusercontent.com/23270317/221276538-56a0b05b-de6d-4c65-a03c-1ec1c39a3039.png">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
