### PR TITLE
Change dashboard standalone mode to fix report screenshot error

### DIFF
--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -42,7 +42,7 @@ const isUserDashboardOwner = (
   user: UserWithPermissionsAndRoles | UndefinedUser,
 ) =>
   isUserWithPermissionsAndRoles(user) &&
-  dashboard.owners.some(owner => owner.username === user.username);
+  dashboard.owners.some(owner => owner.id === user.userId);
 
 export const canUserEditDashboard = (
   dashboard: Dashboard,

--- a/superset/utils/screenshots.py
+++ b/superset/utils/screenshots.py
@@ -236,7 +236,7 @@ class DashboardScreenshot(BaseScreenshot):
         # should always capture in standalone
         url = modify_url_query(
             url,
-            standalone=DashboardStandaloneMode.REPORT.value,
+            standalone=DashboardStandaloneMode.HIDE_NAV_AND_TITLE.value,  # TODO: temp fix for report mode error
         )
 
         super().__init__(url, digest)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When dashboard standalone mode is set to report, the filters are hidden & not shown for a dashboard, preventing the dashboard from loading required filters. Temporarily change dashboard standalone mode as a workaround for this error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
