### PR TITLE
fix(cache warmup): cache warmup 3.1 upgrade

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v3
         with:
           fail-on-severity: high
           # compatible/incompatible licenses addressed here: https://www.apache.org/legal/resolved.html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+default_language_version:
+  node: system
 repos:
   - repo: https://github.com/MarcoGorelli/auto-walrus
     rev: v0.2.2

--- a/superset/common/query_context_processor.py
+++ b/superset/common/query_context_processor.py
@@ -480,13 +480,7 @@ class QueryContextProcessor:
                 offset_metrics_df = offset_metrics_df.rename(columns=metrics_mapping)
 
                 # 3. set time offset for index
-                index = (
-                    [
-                        *get_base_axis_labels(query_object.columns),
-                        query_object.granularity,
-                    ]
-                    or [DTTM_ALIAS]
-                )[0]
+                index = (get_base_axis_labels(query_object.columns) or [DTTM_ALIAS])[0]
                 if not dataframe_utils.is_datetime_series(offset_metrics_df.get(index)):
                     raise QueryObjectValidationError(
                         _(

--- a/superset/config.py
+++ b/superset/config.py
@@ -1664,7 +1664,7 @@ class ExtraRelatedQueryFilters(TypedDict, total=False):
 
 EXTRA_RELATED_QUERY_FILTERS: ExtraRelatedQueryFilters = {}
 
-PINTEREST_MENU_ITEMS: list[PinterestMenuItems] = None
+PINTEREST_MENU_ITEMS: list[PinterestMenuItems] | None = None
 
 
 # Extra dynamic query filters make it possible to limit which objects are shown

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -157,6 +157,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "delete_object": "write",
     "copy_dash": "write",
     "get_connection": "write",
+    "warm_up_cache": "write",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -157,7 +157,6 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "delete_object": "write",
     "copy_dash": "write",
     "get_connection": "write",
-    "warm_up_cache": "write",
 }
 
 EXTRA_FORM_DATA_APPEND_KEYS = {

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -721,14 +721,16 @@ class SupersetIndexView(IndexView):
         return redirect("/superset/welcome/")
 
 
-class ForceHttps:
+class ForceHttps:  # pylint: disable=too-few-public-methods
     """
     wrapper class forces the html schema to be "https"
     """
 
-    def __init__(self, app):
+    def __init__(self, app: Flask) -> None:
         self.app = app
 
-    def __call__(self, environ, start_response):
+    def __call__(
+        self, environ: dict[str, Any], start_response: Callable[..., Any]
+    ) -> Any:
         environ["wsgi.url_scheme"] = "https"
         return self.app(environ, start_response)

--- a/superset/initialization/__init__.py
+++ b/superset/initialization/__init__.py
@@ -607,9 +607,7 @@ class SupersetAppInitializer:  # pylint: disable=too-many-public-methods
             "ENABLE_HTTPS_OVERRIDE" in self.config
             and self.config["ENABLE_HTTPS_OVERRIDE"]
         ):
-            self.superset_app.wsgi_app = ForceHttps(  # type: ignore
-                self.superset_app.wsgi_app
-            )
+            self.superset_app.wsgi_app = ForceHttps(self.superset_app.wsgi_app)
 
         if self.config["ENABLE_CHUNK_ENCODING"]:
 

--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -287,7 +287,7 @@ def fetch_url(data: str, headers: dict[str, str]) -> dict[str, str]:
     """
     result = {}
     try:
-        url = get_url_path("Superset.warm_up_cache")
+        url = get_url_path("ChartRestApi.warm_up_cache")
         logger.info("Fetching %s with payload %s", url, data)
         req = request.Request(
             url, data=bytes(data, "utf-8"), headers=headers, method="PUT"

--- a/superset/tasks/database.py
+++ b/superset/tasks/database.py
@@ -48,13 +48,13 @@ def db_tables_cache_warm_up(database_id: str, schema_name: str) -> None:
             cache_timeout=database.table_cache_timeout,
         )
         logger.info(
-            "Database tables cache warm up succeeded for database_id: %i, schema_name: %s",
+            "Database tables cache warm up succeeded for database_id: %i, schema_name: %s", # pylint: disable=line-too-long
             database_id,
             schema_name,
         )
     except SupersetException as ex:
         logger.exception(
-            "Superset exception for db_tables_cache_warm_up job database_id: %i, schema_name: %s, message: %s",
+            "Superset exception for db_tables_cache_warm_up job database_id: %i, schema_name: %s, message: %s", # pylint: disable=line-too-long
             database_id,
             schema_name,
             ex.message,

--- a/superset/tasks/database.py
+++ b/superset/tasks/database.py
@@ -48,13 +48,13 @@ def db_tables_cache_warm_up(database_id: str, schema_name: str) -> None:
             cache_timeout=database.table_cache_timeout,
         )
         logger.info(
-            "Database tables cache warm up succeeded for database_id: %i, schema_name: %s", # pylint: disable=line-too-long
+            "Database tables cache warm up succeeded for database_id: %i, schema_name: %s",  # pylint: disable=line-too-long
             database_id,
             schema_name,
         )
     except SupersetException as ex:
         logger.exception(
-            "Superset exception for db_tables_cache_warm_up job database_id: %i, schema_name: %s, message: %s", # pylint: disable=line-too-long
+            "Superset exception for db_tables_cache_warm_up job database_id: %i, schema_name: %s, message: %s",  # pylint: disable=line-too-long
             database_id,
             schema_name,
             ex.message,

--- a/tests/integration_tests/tasks/test_cache.py
+++ b/tests/integration_tests/tasks/test_cache.py
@@ -49,7 +49,7 @@ def test_fetch_url(mock_urlopen, mock_request_cls, base_url):
 
     assert data == result["success"]
     mock_request_cls.assert_called_once_with(
-        "http://base-url/superset/warm_up_cache/",
+        "http://base-url/api/v1/chart/warm_up_cache",
         data=data_encoded,
         headers=headers,
         method="PUT",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Add write permission to warm up cache job
* Use chart warm up cache API instead of deprecated API endpoint

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Tested by running warm up job locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
