### PR TITLE
fix: Use machine_auth_provider_factory for cache warmup jobs

### DIFF
--- a/superset/tasks/cache.py
+++ b/superset/tasks/cache.py
@@ -25,7 +25,7 @@ from celery.utils.log import get_task_logger
 from sqlalchemy import and_, func
 
 from superset import app, db, security_manager
-from superset.extensions import celery_app
+from superset.extensions import celery_app, machine_auth_provider_factory
 from superset.models.core import Log
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice
@@ -344,9 +344,10 @@ def cache_warmup(
         return message
 
     user = security_manager.get_user_by_username(app.config["THUMBNAIL_SELENIUM_USER"])
-    cookies = MachineAuthProvider.get_auth_cookies(user)
+    cookies = machine_auth_provider_factory.instance.get_auth_cookies(user)
+    cookie_str = ";".join([f"{key}={val}" for key, val in cookies.items()])
     headers = {
-        "Cookie": f"session={cookies.get('session', '')}",
+        "Cookie": cookie_str,
         "Content-Type": "application/json",
     }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Use machine_auth_provider_factory for cache warmup jobs (to use custom implementations of the machine auth provider)
* Pass all cookies from machine_auth_provider through request

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
