### PR TITLE
Add golden dashboards to home page

### DIFF
--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -50,6 +50,7 @@ function DashboardTable({
   addDangerToast,
   addSuccessToast,
   mine,
+  golden,
   showThumbnails,
   otherTabData,
   otherTabFilters,
@@ -58,7 +59,7 @@ function DashboardTable({
   const history = useHistory();
   const defaultTab = getItem(
     LocalStorageKeys.HomepageDashboardFilter,
-    TableTab.Other,
+    TableTab.Golden,
   );
 
   const filteredOtherTabData = filter(
@@ -77,7 +78,11 @@ function DashboardTable({
     t('dashboard'),
     addDangerToast,
     true,
-    defaultTab === TableTab.Mine ? mine : filteredOtherTabData,
+    defaultTab === TableTab.Mine
+      ? mine
+      : defaultTab === TableTab.Golden
+        ? golden
+        : filteredOtherTabData,
     [],
     false,
   );
@@ -151,6 +156,14 @@ function DashboardTable({
     );
 
   const menuTabs = [
+    {
+      name: TableTab.Golden,
+      label: t('Golden'),
+      onClick: () => {
+        setActiveTab(TableTab.Golden);
+        setItem(LocalStorageKeys.HomepageDashboardFilter, TableTab.Golden);
+      },
+    },
     {
       name: TableTab.Favorite,
       label: t('Favorite'),

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -221,7 +221,9 @@ function DashboardTable({
                   ? `/dashboard/list/?filters=(favorite:(label:${t(
                       'Yes',
                     )},value:!t))`
-                  : '/dashboard/list/';
+                  : activeTab === TableTab.Top
+                    ? `/dashboard/list/?filters=(tags:(label:Top,value:Top))`
+                    : '/dashboard/list/';
               history.push(target);
             },
           },

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -50,7 +50,7 @@ function DashboardTable({
   addDangerToast,
   addSuccessToast,
   mine,
-  golden,
+  top,
   showThumbnails,
   otherTabData,
   otherTabFilters,
@@ -59,7 +59,7 @@ function DashboardTable({
   const history = useHistory();
   const defaultTab = getItem(
     LocalStorageKeys.HomepageDashboardFilter,
-    TableTab.Golden,
+    TableTab.Top,
   );
 
   const filteredOtherTabData = filter(
@@ -80,8 +80,8 @@ function DashboardTable({
     true,
     defaultTab === TableTab.Mine
       ? mine
-      : defaultTab === TableTab.Golden
-        ? golden
+      : defaultTab === TableTab.Top
+        ? top
         : filteredOtherTabData,
     [],
     false,
@@ -157,11 +157,11 @@ function DashboardTable({
 
   const menuTabs = [
     {
-      name: TableTab.Golden,
-      label: t('Golden'),
+      name: TableTab.Top,
+      label: t('Top'),
       onClick: () => {
-        setActiveTab(TableTab.Golden);
-        setItem(LocalStorageKeys.HomepageDashboardFilter, TableTab.Golden);
+        setActiveTab(TableTab.Top);
+        setItem(LocalStorageKeys.HomepageDashboardFilter, TableTab.Top);
       },
     },
     {

--- a/superset-frontend/src/features/home/EmptyState.tsx
+++ b/superset-frontend/src/features/home/EmptyState.tsx
@@ -127,7 +127,8 @@ export default function EmptyState({
   if (
     tab === TableTab.Mine ||
     tableName === WelcomeTable.Recents ||
-    tab === TableTab.Other
+    tab === TableTab.Other ||
+    tab === TableTab.Golden
   ) {
     return (
       <EmptyContainer>

--- a/superset-frontend/src/features/home/EmptyState.tsx
+++ b/superset-frontend/src/features/home/EmptyState.tsx
@@ -128,7 +128,7 @@ export default function EmptyState({
     tab === TableTab.Mine ||
     tableName === WelcomeTable.Recents ||
     tab === TableTab.Other ||
-    tab === TableTab.Golden
+    tab === TableTab.Top
   ) {
     return (
       <EmptyContainer>

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -41,7 +41,7 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import {
   CardContainer,
   createErrorHandler,
-  getGoldenDashboards,
+  getTopDashboards,
   getRecentActivityObjs,
   getUserOwnedObjects,
   loadingCardCount,
@@ -177,7 +177,7 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const [dashboardData, setDashboardData] = useState<Array<object> | null>(
     null,
   );
-  const [goldenDashboardData, setGoldenDashboardData] =
+  const [topDashboardData, setTopDashboardData] =
     useState<Array<object> | null>(null);
   const [isFetchingActivityData, setIsFetchingActivityData] = useState(true);
 
@@ -301,15 +301,15 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ]).then(() => {
       setIsFetchingActivityData(false);
     });
-    getGoldenDashboards()
+    getTopDashboards()
       .then(r => {
-        setGoldenDashboardData(r);
+        setTopDashboardData(r);
         return Promise.resolve();
       })
       .catch((err: unknown) => {
-        setGoldenDashboardData([]);
+        setTopDashboardData([]);
         addDangerToast(
-          t('There was an issue fetching golden dashboards: %s', err),
+          t('There was an issue fetching top dashboards: %s', err),
         );
         return Promise.resolve();
       });
@@ -380,21 +380,6 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               ghost
               bigger
             >
-              <Collapse.Panel header={t('Dashboards')} key="2">
-                {!dashboardData || isRecentActivityLoading ? (
-                  <LoadingCards cover={checked} />
-                ) : (
-                  <DashboardTable
-                    user={user}
-                    mine={dashboardData}
-                    golden={goldenDashboardData}
-                    showThumbnails={checked}
-                    otherTabData={activityData?.[TableTab.Other]}
-                    otherTabFilters={otherTabFilters}
-                    otherTabTitle={otherTabTitle}
-                  />
-                )}
-              </Collapse.Panel>
               <Collapse.Panel header={t('Recents')} key="1">
                 {activityData &&
                 (activityData[TableTab.Viewed] ||
@@ -410,6 +395,21 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                   />
                 ) : (
                   <LoadingCards />
+                )}
+              </Collapse.Panel>
+              <Collapse.Panel header={t('Dashboards')} key="2">
+                {!dashboardData || isRecentActivityLoading ? (
+                  <LoadingCards cover={checked} />
+                ) : (
+                  <DashboardTable
+                    user={user}
+                    mine={dashboardData}
+                    top={topDashboardData}
+                    showThumbnails={checked}
+                    otherTabData={activityData?.[TableTab.Other]}
+                    otherTabFilters={otherTabFilters}
+                    otherTabTitle={otherTabTitle}
+                  />
                 )}
               </Collapse.Panel>
               <Collapse.Panel header={t('Charts')} key="3">

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -298,21 +298,21 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               return Promise.resolve();
             })
         : Promise.resolve(),
+      getTopDashboards()
+        .then(r => {
+          setTopDashboardData(r);
+          return Promise.resolve();
+        })
+        .catch((err: unknown) => {
+          setTopDashboardData([]);
+          addDangerToast(
+            t('There was an issue fetching top dashboards: %s', err),
+          );
+          return Promise.resolve();
+        }),
     ]).then(() => {
       setIsFetchingActivityData(false);
     });
-    getTopDashboards()
-      .then(r => {
-        setTopDashboardData(r);
-        return Promise.resolve();
-      })
-      .catch((err: unknown) => {
-        setTopDashboardData([]);
-        addDangerToast(
-          t('There was an issue fetching top dashboards: %s', err),
-        );
-        return Promise.resolve();
-      });
   }, [otherTabFilters]);
 
   const handleToggle = () => {

--- a/superset-frontend/src/pages/Home/index.tsx
+++ b/superset-frontend/src/pages/Home/index.tsx
@@ -41,6 +41,7 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import {
   CardContainer,
   createErrorHandler,
+  getGoldenDashboards,
   getRecentActivityObjs,
   getUserOwnedObjects,
   loadingCardCount,
@@ -176,6 +177,8 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
   const [dashboardData, setDashboardData] = useState<Array<object> | null>(
     null,
   );
+  const [goldenDashboardData, setGoldenDashboardData] =
+    useState<Array<object> | null>(null);
   const [isFetchingActivityData, setIsFetchingActivityData] = useState(true);
 
   const collapseState = getItem(LocalStorageKeys.HomepageCollapseState, []);
@@ -298,6 +301,18 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
     ]).then(() => {
       setIsFetchingActivityData(false);
     });
+    getGoldenDashboards()
+      .then(r => {
+        setGoldenDashboardData(r);
+        return Promise.resolve();
+      })
+      .catch((err: unknown) => {
+        setGoldenDashboardData([]);
+        addDangerToast(
+          t('There was an issue fetching golden dashboards: %s', err),
+        );
+        return Promise.resolve();
+      });
   }, [otherTabFilters]);
 
   const handleToggle = () => {
@@ -365,6 +380,21 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
               ghost
               bigger
             >
+              <Collapse.Panel header={t('Dashboards')} key="2">
+                {!dashboardData || isRecentActivityLoading ? (
+                  <LoadingCards cover={checked} />
+                ) : (
+                  <DashboardTable
+                    user={user}
+                    mine={dashboardData}
+                    golden={goldenDashboardData}
+                    showThumbnails={checked}
+                    otherTabData={activityData?.[TableTab.Other]}
+                    otherTabFilters={otherTabFilters}
+                    otherTabTitle={otherTabTitle}
+                  />
+                )}
+              </Collapse.Panel>
               <Collapse.Panel header={t('Recents')} key="1">
                 {activityData &&
                 (activityData[TableTab.Viewed] ||
@@ -380,20 +410,6 @@ function Welcome({ user, addDangerToast }: WelcomeProps) {
                   />
                 ) : (
                   <LoadingCards />
-                )}
-              </Collapse.Panel>
-              <Collapse.Panel header={t('Dashboards')} key="2">
-                {!dashboardData || isRecentActivityLoading ? (
-                  <LoadingCards cover={checked} />
-                ) : (
-                  <DashboardTable
-                    user={user}
-                    mine={dashboardData}
-                    showThumbnails={checked}
-                    otherTabData={activityData?.[TableTab.Other]}
-                    otherTabFilters={otherTabFilters}
-                    otherTabTitle={otherTabTitle}
-                  />
                 )}
               </Collapse.Panel>
               <Collapse.Panel header={t('Charts')} key="3">

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -32,7 +32,7 @@ export enum TableTab {
   Viewed = 'Viewed',
   Created = 'Created',
   Edited = 'Edited',
-  Golden = 'Golden',
+  Top = 'Top',
 }
 
 export type Filter = {
@@ -46,7 +46,7 @@ export interface DashboardTableProps {
   addSuccessToast: (message: string) => void;
   user?: User;
   mine: Array<Dashboard>;
-  golden: Array<Dashboard>;
+  top: Array<Dashboard>;
   showThumbnails?: boolean;
   otherTabData: Array<Dashboard>;
   otherTabFilters: Filter[];

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -32,6 +32,7 @@ export enum TableTab {
   Viewed = 'Viewed',
   Created = 'Created',
   Edited = 'Edited',
+  Golden = 'Golden',
 }
 
 export type Filter = {
@@ -45,6 +46,7 @@ export interface DashboardTableProps {
   addSuccessToast: (message: string) => void;
   user?: User;
   mine: Array<Dashboard>;
+  golden: Array<Dashboard>;
   showThumbnails?: boolean;
   otherTabData: Array<Dashboard>;
   otherTabFilters: Filter[];

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -574,5 +574,14 @@ export function getFilterValues(
       value: flt.value,
     }));
   }
+  if (tab === TableTab.Top) {
+    return [
+      {
+        id: 'tags',
+        operator: 'dashboard_tags',
+        value: 'Top',
+      },
+    ];
+  }
   return [];
 }

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -167,12 +167,12 @@ export const getEditedObjects = (userId: string | number) => {
     .catch(err => err);
 };
 
-export const getGoldenDashboards = (
+export const getTopDashboards = (
   filters: Filter[] = [
     {
       col: 'tags',
       opr: 'dashboard_tags',
-      value: 'Golden',
+      value: 'Top',
     },
   ],
 ) =>

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -167,6 +167,19 @@ export const getEditedObjects = (userId: string | number) => {
     .catch(err => err);
 };
 
+export const getGoldenDashboards = (
+  filters: Filter[] = [
+    {
+      col: 'tags',
+      opr: 'dashboard_tags',
+      value: 'Golden',
+    },
+  ],
+) =>
+  SupersetClient.get({
+    endpoint: `/api/v1/dashboard/?q=${getParams(filters)}`,
+  }).then(res => res.json?.result);
+
 export const getUserOwnedObjects = (
   userId: string | number,
   resource: string,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Add golden dashboards to home page
* Move "Dashboards" tab to top of homepage

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1633" alt="Screenshot 2024-11-17 at 2 15 54 PM" src="https://github.com/user-attachments/assets/26c2f492-d407-4bf6-b96f-5d019116b8b6">

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
