### PR TITLE
Fix daylight savings bug in Pinterest delta table tooltip

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/pinterest-utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/pinterest-utils/tooltip.ts
@@ -33,9 +33,17 @@ import { getTooltipTimeFormatter } from '../utils/formatters';
 import { DeltaDirection, DeltaTableColumn } from './types';
 
 const getPreviousDate = (date: Date, offsetDays: number) => {
-  const previousDate = new Date(date);
-  previousDate.setDate(date.getDate() - offsetDays);
-  return previousDate;
+  // Convert the date to UTC time in milliseconds, subtract the offsetDays,
+  // and return the new date. (UTC conversion is needed to avoid daylight savings issues)
+  const time = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  );
+  // subtract offsetDays from the time in milliseconds
+  const newTime = time - offsetDays * 24 * 60 * 60 * 1000;
+  const newDate = new Date(newTime);
+  return newDate;
 };
 
 export const getDateByTimeDelta = {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Dates need to be converted to UTC timestamp before getting date offset (because date offset allows for daylight savings error)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
