### PR TITLE
[Dataset Explorer] API & Logic: Superset Embed By Slug - [Part 2/2]

### DIFF
--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -43,6 +43,7 @@ class EmbeddedView(BaseSupersetView):
         """
         Server side rendering for the embedded dashboard page
         :param uuid: identifier for embedded dashboard
+            [pinterest-specific]: can use dashboard id or slug as uuid
         :param add_extra_log_payload: added by `log_this_with_manual_updates`, set a
             default value to appease pylint
         """
@@ -50,6 +51,26 @@ class EmbeddedView(BaseSupersetView):
             abort(404)
 
         embedded = EmbeddedDashboardDAO.find_by_id(uuid)
+
+        # [pinterest-specific] Allow embedding by dashboard id or slug
+        if not embedded and is_feature_enabled(
+            "PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG"
+        ):
+            from superset import conf
+            from superset.models.dashboard import Dashboard
+            from superset.models.embedded_dashboard import EmbeddedDashboard
+
+            dashboard = Dashboard.get(uuid)
+
+            if dashboard:
+                embedded = EmbeddedDashboard()
+                embedded.allow_domain_list = ",".join(
+                    conf.get(
+                        "PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG_ALLOWED_DOMAINS"
+                    )
+                )
+                embedded.dashboard_id = dashboard.id
+                uuid = None
 
         if not embedded:
             abort(404)
@@ -74,6 +95,8 @@ class EmbeddedView(BaseSupersetView):
         add_extra_log_payload(
             embedded_dashboard_id=uuid,
             dashboard_version="v2",
+            # [pinterest-specific]
+            embedded_by_id_or_slug=uuid is None,
         )
 
         bootstrap_data = {

--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -95,8 +95,8 @@ class EmbeddedView(BaseSupersetView):
         add_extra_log_payload(
             embedded_dashboard_id=uuid,
             dashboard_version="v2",
-            # [pinterest-specific]
-            embedded_by_id_or_slug=uuid is None,
+            # [pinterest-specific] Only add extra log payload if uuid is None.
+            **({"embedded_by_id_or_slug": True} if uuid is None else {}),
         )
 
         bootstrap_data = {


### PR DESCRIPTION
### SUMMARY
We have scenarios where apps generate a lot of dashboards. In order to embed these dashboards, we need to create embedding configs for each and every one of them. Although this works, it adds an overhead with implementation and every team that needs such usage will have to do the same thing on their end.

This PR (part 2 of https://github.com/pinternal/superset-pinterest/pull/68) allows users to embed dashboards without creating an embedding config (and using `embedded.uuid`), just by the `dashboard.id` or `dashboard.slug`.

#### What are the changes doing:
##### `superset/embedded/view.py`
Using a new feature flag `PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG`, we check to see if the embedded config is found for the dashboard based on the given `uuid`.
=> If embedded config is found, our changes have no effect.

Otherwise, we make an assumption that the given `uuid` is either a `dashboard.id` or `dashboard.slug`. With that in mind, we try to find the dashboard.
=> If dashboard is not found, our changes have no effect.

Otherwise, we use the found dashboard info to create a temp `EmbeddedDashboard` to replace the not found `embedded` value. Here we need two important piece of info:
1. `dashboard.id`: This will be used to get the dashboard details for embedding.
2. `allowed_domain_list`: This value will come from `PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG_ALLOWED_DOMAINS` which is added in the part 1 PR above. This was added to ensure that we only allow requesting domains / apps to use this feature. This will give us more control and better visibility on who relies on this usage.

With our temp `EmbeddedDashboard`, we let the default logic flow and make no further changes other than adding extra log value to the payload if and only if `uuid` is `None`, meaning that our feature is being utilized. This will ensure that regular usage doesn't include an unnecessary false in the payload.

---

##### `superset/security/api.py`
Here we ensure that the id value provided to the schema to generate the guest token is actually the `dashboard.id` and not `dashboard.slug` or `embedded.uuid`. We ensure this by finding the dashboard with the given `id` value which could be any of the 3 and if the dashboard is found, then we update the id value with the `dashboard.id`. Note that we only do this if our new feature flag `PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG` is enabled.

---

With these changes in place, the new flow is the following:
1. User makes a request to get a guest token and provides `dashboard.slug` in the request.
  - Backend receives this slug and prior to generating the guest token, converts it to `dashboard.id` so the hash now contains the `id` instead of `slug`.
2. User then makes an embed request with the retrieved guest token and provdes `dashboard.slug` in the [`embedDashboard` call from the SDK](https://github.com/pinterest/superset/blob/pinterest-release-4.0.2/superset-embedded-sdk/src/index.ts).
  - The hook gets the guest token and then mounts the iframe. After iframe is mounted, it sets up the message channel and after the handshake, it's now ready to make the calls to paint the dashboard.
  - For this, it sets up a local client with the guest token and then makes 3 requests to dashboard, datasets and charts. If the guest token does NOT contain the `dashboard.id`, the first call fails which blocks the other two. We will explain the failure below.
  - If the `dashboard.id` was in the guest token hash, then this authorizes the user, the API calls are successful and once fetched, the dashboard logic kicks in and paints the dashboard view in the embedded UI.

Flow of request to get the dashboard after the iframe is mounted and handshake is complete:
```
1. public/superset/dashboards/api.py DashboardRestApi.get(...)
^ API endpoint, calls `with_dashboard`:
2. public/superset/dashboards/api.py with_dashboard(...)
^ decorator to get and pass the dashboard, calls `DashboardDAO.get_by_id_or_slug`:
3. public/superset/daos/dashboard.py DashboardDAO.get_by_id_or_slug
^ Pretty much the core method for finding a dashboard, allows finding dashboard by `dashboard.id`, `dashboard.slug` and `embedded.uuid`. After the dashboard is found - or not, it calls `dashboard.raise_for_access`:
4. public/superset/daos/dashboard.py dashboard.raise_for_access()
^ Fails if the guest token contains `dashboard.slug` instead of `dashboard.id`. Since our guest token contains parsed `dashboard.id` from the `dashboard.slug`, we bypass this issue without giving up on the security.
```
With this flow in mind, I did explore option to allow `dashboard.slug` to be used for access / oauth check. This required quite a few changes as it seems like not all checks support both `dashboard.slug` and `dashboard.id`. It was after a lot of testing that i was able to figure out that this was even the issue as there were too many variables to test with that resulted in different kind of errors and eventually figured out that the combination of guest token with `dashboard.id` is pretty much the main requirement for oauth.

Other solutions considered:
- Post guest token generation, allow service account to generate an embedding config.
  - This can be harmful in case where a user can abuse this system to generate embedded configs by using our app. Even if we add an extra layer of security around it, this would mean that we would be filling the db with a lot of embed configs. Although this is not a real issue, it's an overhead.
- Embed without embedded endpoint.
  - You can actually embed the dashboard without any of these changes. In the iframe src, instead of using `/embedded/<uuid>`, use `/dashboard/<dashboard_id_or_slug>`, which is the same url that is used to visit the superset ui. This allows embedding of the dashboard without a hassle. The drawback here is the user is required to be logged in in the browser session. Unfortuantely, we have no way of getting this session information to check if the user is logged in or not as the API calls by default will fail and with service account, we would always be logged in. Also, if the user is not logged in, the embedded superset has the `login` button but since it's inside the iframe, clicking on that button redirects to a failed page and the user cannot use the iframe to login. To overcome this, in the UI, we would display a `login` button on top of the dashboard which would take the user to the superset dashboard and after they login, they would come back to the ui and we would auto refresh the dashboard. Again, this is not possible based on the limited research, but even if it was, this would both require extra work for users to see the dashboard easily, and it would require customers to make a change on their app.

This solution in the PR is the least invasive and allows plug and play for other customers as long as they add their domain to `PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG_ALLOWED_DOMAINS`. It follows the default security standard and ensures that our changes don't give any extra leeway to the customers.

If you have read thus far, thank you! This was quite a journey in itself with a lot of debugging and having to learn quite a bit if superset to come up with this solution. Although it's such a small change, there are quite a few layers to go inbetween (UI, sdk, pinterest wrapper, og superset, fab). I hope that I haven't missed anything and this makes sense and we are good to deploy!

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
N/A

### TESTING INSTRUCTIONS
Instead of using:
- `dashboardId` for the guest token generation
- `embeddedUUID` for the `embedDashboard` call (or embedded iframe url)
Provide the `dashboardSlug` to both.
Embedded dashboard should load without any errors without user logging in as long as the guest token generator logic sends the `dashboardSlug`

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [x] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
