### PR TITLE
fix(databases): Fix filter for database permissions.

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -57,7 +57,9 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import UniqueConstraint
-from sqlalchemy.sql import ColumnElement, expression, Select
+
+# pylint: disable=unused-import
+from sqlalchemy.sql import ColumnElement, Select
 
 from superset import app, db_engine_specs, is_feature_enabled
 from superset.commands.database.exceptions import DatabaseInvalidError
@@ -1019,9 +1021,7 @@ class Database(Model, AuditMixinNullable, ImportExportMixin):  # pylint: disable
 
     @perm.expression  # type: ignore
     def perm(cls) -> str:  # pylint: disable=no-self-argument
-        return (
-            "[" + cls.database_name + "].(id:" + expression.cast(cls.id, String) + ")"
-        )
+        return sqla.func.concat("[", cls.database_name, "].(id:", cls.id, ")")
 
     def get_perm(self) -> str:
         return self.perm  # type: ignore

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -57,8 +57,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import UniqueConstraint
-
-# pylint: disable=unused-import
 from sqlalchemy.sql import ColumnElement, Select
 
 from superset import app, db_engine_specs, is_feature_enabled


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
SQL query is resulting in error "Illegal mix of collations for operation ' IN '" with previous filter.
Error occurs when you're trying to compare or perform operations on strings with different collations that aren't compatible (in this case the int being cast to a string is incompatible). Removed casting & directly concatenated to avoid error.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
