### PR TITLE
fix(dashboard): enable dashboard's "Save as" menu option for all users

### DIFF
--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -65,6 +65,13 @@ const owner: Owner = {
   last_name: 'User',
 };
 
+const readOnlyUser: UserWithPermissionsAndRoles = {
+  ...ownerUser,
+  roles: { Alpha: [['can_read', 'Dashboard']] },
+  userId: 4,
+  username: 'readonly',
+};
+
 const sqlLabMenuAccessPermission: [string, string] = ['menu_access', 'SQL Lab'];
 
 const arbitraryPermissions: [string, string][] = [
@@ -182,56 +189,16 @@ test('userHasPermission returns true if user has permission', () => {
   ).toEqual(true);
 });
 
-describe('canUserSaveAsDashboard with RBAC feature flag disabled', () => {
-  beforeAll(() => {
-    isFeatureEnabledMock = jest
-      .spyOn(uiCore, 'isFeatureEnabled')
-      .mockImplementation(
-        (featureFlag: uiCore.FeatureFlag) =>
-          featureFlag !== uiCore.FeatureFlag.DashboardRbac,
-      );
-  });
-
-  afterAll(() => {
-    isFeatureEnabledMock.mockRestore();
-  });
-
-  it('allows owners', () => {
-    expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
-  });
-
-  it('allows admin users', () => {
-    expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
-  });
-
-  it('allows non-owners', () => {
-    expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(true);
-  });
+test('canUserSaveAsDashboard returns true if user has write permission', () => {
+  expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
+  expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
+  expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(true);
 });
 
-describe('canUserSaveAsDashboard with RBAC feature flag enabled', () => {
-  beforeAll(() => {
-    isFeatureEnabledMock = jest
-      .spyOn(uiCore, 'isFeatureEnabled')
-      .mockImplementation(
-        (featureFlag: uiCore.FeatureFlag) =>
-          featureFlag === uiCore.FeatureFlag.DashboardRbac,
-      );
-  });
+test('canUserSaveAsDashboard returns false if user does not have write permission', () => {
+  expect(canUserSaveAsDashboard(dashboard, readOnlyUser)).toEqual(false);
+});
 
-  afterAll(() => {
-    isFeatureEnabledMock.mockRestore();
-  });
-
-  it('allows owners', () => {
-    expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
-  });
-
-  it('allows admin users', () => {
-    expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
-  });
-
-  it('reject non-owners', () => {
-    expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(false);
-  });
+test('canUserSaveAsDashboard always returns false for undefined user', () => {
+  expect(canUserSaveAsDashboard(dashboard, undefinedUser)).toEqual(false);
 });

--- a/superset-frontend/src/dashboard/util/permissionUtils.test.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.test.ts
@@ -202,3 +202,59 @@ test('canUserSaveAsDashboard returns false if user does not have write permissio
 test('canUserSaveAsDashboard always returns false for undefined user', () => {
   expect(canUserSaveAsDashboard(dashboard, undefinedUser)).toEqual(false);
 });
+
+// The usage of the RBAC feature flag was removed from canUserSaveAsDashboard.
+// Skipping the old test cases for future rebases.
+describe.skip('canUserSaveAsDashboard with RBAC feature flag disabled', () => {
+  beforeAll(() => {
+    isFeatureEnabledMock = jest
+      .spyOn(uiCore, 'isFeatureEnabled')
+      .mockImplementation(
+        (featureFlag: uiCore.FeatureFlag) =>
+          featureFlag !== uiCore.FeatureFlag.DashboardRbac,
+      );
+  });
+
+  afterAll(() => {
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('allows owners', () => {
+    expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
+  });
+
+  it('allows admin users', () => {
+    expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
+  });
+
+  it('allows non-owners', () => {
+    expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(true);
+  });
+});
+
+describe.skip('canUserSaveAsDashboard with RBAC feature flag enabled', () => {
+  beforeAll(() => {
+    isFeatureEnabledMock = jest
+      .spyOn(uiCore, 'isFeatureEnabled')
+      .mockImplementation(
+        (featureFlag: uiCore.FeatureFlag) =>
+          featureFlag === uiCore.FeatureFlag.DashboardRbac,
+      );
+  });
+
+  afterAll(() => {
+    isFeatureEnabledMock.mockRestore();
+  });
+
+  it('allows owners', () => {
+    expect(canUserSaveAsDashboard(dashboard, ownerUser)).toEqual(true);
+  });
+
+  it('allows admin users', () => {
+    expect(canUserSaveAsDashboard(dashboard, adminUser)).toEqual(true);
+  });
+
+  it('reject non-owners', () => {
+    expect(canUserSaveAsDashboard(dashboard, outsiderUser)).toEqual(false);
+  });
+});

--- a/superset-frontend/src/dashboard/util/permissionUtils.ts
+++ b/superset-frontend/src/dashboard/util/permissionUtils.ts
@@ -75,7 +75,4 @@ export const canUserSaveAsDashboard = (
   user?: UserWithPermissionsAndRoles | UndefinedUser | null,
 ) =>
   isUserWithPermissionsAndRoles(user) &&
-  findPermission('can_write', 'Dashboard', user?.roles) &&
-  (!isFeatureEnabled(FeatureFlag.DashboardRbac) ||
-    isUserAdmin(user) ||
-    isUserDashboardOwner(dashboard, user));
+  findPermission('can_write', 'Dashboard', user?.roles);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Removed the RBAC feature flag and user type checks in when checking `canUserSaveAsDashboard` permissions
* Allow all users to use the "Save as" menu option in a dashboard

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
* Open a dashboard as a non-admin and non-owner, "Save as" should be available on every dashboard

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
