### PR TITLE
fix(dashboard): Display username in dashboard owner's filter and dashboard access field

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -159,18 +159,10 @@ const PropertiesModal = ({
           .filter((item: { extra: { active: boolean } }) =>
             item.extra.active !== undefined ? item.extra.active : true,
           )
-          .map(
-            (item: {
-              value: number;
-              text: string;
-              extra: { username: string };
-            }) => ({
-              value: item.value,
-              label: item.extra?.username
-                ? `${item.text} (${item.extra.username})`
-                : item.text,
-            }),
-          ),
+          .map((item: { value: number; text: string }) => ({
+            value: item.value,
+            label: item.text,
+          })),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -164,10 +164,18 @@ const PropertiesModal = ({
           .filter((item: { extra: { active: boolean } }) =>
             item.extra.active !== undefined ? item.extra.active : true,
           )
-          .map((item: { value: number; text: string }) => ({
-            value: item.value,
-            label: item.text,
-          })),
+          .map(
+            (item: {
+              value: number;
+              text: string;
+              extra: { username: string };
+            }) => ({
+              value: item.value,
+              label: item.extra?.username
+                ? `${item.text} (${item.extra.username})`
+                : item.text,
+            }),
+          ),
         totalCount: response.json.count,
       }));
     },

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -50,7 +50,7 @@ import {
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
-import getOwnerName from 'src/utils/getOwnerName';
+import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
 
 const StyledFormItem = styled(FormItem)`
@@ -77,12 +77,7 @@ type PropertiesModalProps = {
 };
 
 type Roles = { id: number; name: string }[];
-type Owners = {
-  id: number;
-  full_name?: string;
-  first_name?: string;
-  last_name?: string;
-}[];
+type Owners = Owner[];
 type DashboardInfo = {
   id: number;
   title: string;
@@ -274,7 +269,7 @@ const PropertiesModal = ({
   const handleOwnersSelectValue = () => {
     const parsedOwners = (owners || []).map((owner: Owner) => ({
       value: owner.id,
-      label: getOwnerName(owner),
+      label: getOwnerDisplayName(owner),
     }));
     return parsedOwners;
   };

--- a/superset-frontend/src/features/alerts/AlertReportModal.tsx
+++ b/superset-frontend/src/features/alerts/AlertReportModal.tsx
@@ -66,6 +66,7 @@ import {
 } from 'src/features/alerts/types';
 import { useSelector } from 'react-redux';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import NumberInput from './components/NumberInput';
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { NotificationMethod } from './components/NotificationMethod';
@@ -1164,7 +1165,13 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
           ? [
               {
                 value: currentUser.userId,
-                label: `${currentUser.firstName} ${currentUser.lastName}`,
+                // label: `${currentUser.firstName} ${currentUser.lastName}`
+                label: getOwnerDisplayName({
+                  ...currentUser,
+                  first_name: currentUser.firstName,
+                  last_name: currentUser.lastName,
+                  id: currentUser.userId,
+                } as Owner),
               },
             ]
           : [],
@@ -1243,8 +1250,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
         owners: (alert?.owners || []).map(owner => ({
           value: (owner as MetaObject).value || owner.id,
           label:
-            (owner as MetaObject).label ||
-            `${(owner as Owner).first_name} ${(owner as Owner).last_name}`,
+            // (owner as MetaObject).label ||
+            // `${(owner as Owner).first_name} ${(owner as Owner).last_name}`,
+            (owner as MetaObject).label || getOwnerDisplayName(owner as Owner),
         })),
         // @ts-ignore: Type not assignable
         validator_config_json:

--- a/superset-frontend/src/pages/AlertReportList/index.tsx
+++ b/superset-frontend/src/pages/AlertReportList/index.tsx
@@ -76,6 +76,7 @@ interface AlertListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 const deleteAlerts = makeApi<number[], { message: string }>({

--- a/superset-frontend/src/pages/AnnotationLayerList/index.tsx
+++ b/superset-frontend/src/pages/AnnotationLayerList/index.tsx
@@ -47,6 +47,7 @@ interface AnnotationLayersListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -149,6 +149,7 @@ interface ChartListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/CssTemplateList/index.tsx
+++ b/superset-frontend/src/pages/CssTemplateList/index.tsx
@@ -47,6 +47,7 @@ interface CssTemplatesListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -30,6 +30,7 @@ import rison from 'rison';
 import {
   createFetchRelated,
   createErrorHandler,
+  createFetchRelatedFormatted,
   handleDashboardDelete,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
@@ -90,6 +91,7 @@ interface DashboardListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username?: string;
   };
 }
 
@@ -557,7 +559,7 @@ function DashboardList(props: DashboardListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelated(
+        fetchSelects: createFetchRelatedFormatted(
           'dashboard',
           'owners',
           createErrorHandler(errMsg =>
@@ -568,6 +570,10 @@ function DashboardList(props: DashboardListProps) {
               ),
             ),
           ),
+          (data: { text: string; value: string | number; extra?: any }) =>
+            data.extra?.username
+              ? `${data.text} (${data.extra.username})`
+              : data.text,
           props.user,
         ),
         paginate: true,

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -90,7 +90,6 @@ interface DashboardListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
-    username?: string;
   };
 }
 

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -30,7 +30,6 @@ import rison from 'rison';
 import {
   createFetchRelated,
   createErrorHandler,
-  createFetchRelatedFormatted,
   handleDashboardDelete,
 } from 'src/views/CRUD/utils';
 import { useListViewResource, useFavoriteStatus } from 'src/views/CRUD/hooks';
@@ -559,7 +558,7 @@ function DashboardList(props: DashboardListProps) {
         input: 'select',
         operator: FilterOperator.RelationManyMany,
         unfilteredLabel: t('All'),
-        fetchSelects: createFetchRelatedFormatted(
+        fetchSelects: createFetchRelated(
           'dashboard',
           'owners',
           createErrorHandler(errMsg =>
@@ -570,10 +569,6 @@ function DashboardList(props: DashboardListProps) {
               ),
             ),
           ),
-          (data: { text: string; value: string | number; extra?: any }) =>
-            data.extra?.username
-              ? `${data.text} (${data.extra.username})`
-              : data.text,
           props.user,
         ),
         paginate: true,

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -90,6 +90,7 @@ interface DashboardListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/DatabaseList/index.tsx
+++ b/superset-frontend/src/pages/DatabaseList/index.tsx
@@ -76,6 +76,7 @@ interface DatabaseListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -131,6 +131,7 @@ interface DatasetListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
+++ b/superset-frontend/src/pages/RowLevelSecurityList/index.tsx
@@ -48,6 +48,7 @@ interface RLSProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/SavedQueryList/index.tsx
+++ b/superset-frontend/src/pages/SavedQueryList/index.tsx
@@ -82,6 +82,7 @@ interface SavedQueryListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/pages/Tags/index.tsx
+++ b/superset-frontend/src/pages/Tags/index.tsx
@@ -52,6 +52,7 @@ interface TagListProps {
     userId: string | number;
     firstName: string;
     lastName: string;
+    username: string;
   };
 }
 

--- a/superset-frontend/src/types/Owner.ts
+++ b/superset-frontend/src/types/Owner.ts
@@ -26,4 +26,5 @@ export default interface Owner {
   id: number;
   last_name?: string;
   full_name?: string;
+  username?: string;
 }

--- a/superset-frontend/src/utils/getOwnerName.ts
+++ b/superset-frontend/src/utils/getOwnerName.ts
@@ -24,3 +24,14 @@ export default function getOwnerName(owner?: Owner): string {
   }
   return owner.full_name || `${owner.first_name} ${owner.last_name}`;
 }
+
+export function getOwnerDisplayName(owner?: Owner): string {
+  if (!owner) {
+    return '';
+  }
+
+  if (owner.username) {
+    return `${getOwnerName(owner)} (${owner.username})`;
+  }
+  return getOwnerName(owner);
+}

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -76,7 +76,12 @@ const createFetchResourceMethod =
     resource: string,
     relation: string,
     handleError: (error: Response) => void,
-    user?: { userId: string | number; firstName: string; lastName: string },
+    user?: {
+      userId: string | number;
+      firstName: string;
+      lastName: string;
+      username: string;
+    },
   ) =>
   async (filterValue = '', page: number, pageSize: number) => {
     const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
@@ -94,6 +99,7 @@ const createFetchResourceMethod =
       ? {
           label: `${user.firstName} ${user.lastName}`,
           value: user.userId,
+          username: user.username,
         }
       : undefined;
 
@@ -104,7 +110,8 @@ const createFetchResourceMethod =
         if (
           loggedUser &&
           value === loggedUser.value &&
-          text === loggedUser.label
+          (text === loggedUser.label ||
+            text === `${loggedUser.label} (${loggedUser.username})`)
         ) {
           fetchedLoggedUser = true;
         } else {

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -195,8 +195,6 @@ const createFetchResourceMethodFormatted =
       data.unshift(loggedUser);
     }
 
-    console.log(data);
-
     return {
       data,
       totalCount: json?.count,

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -125,6 +125,84 @@ const createFetchResourceMethod =
     };
   };
 
+const createFetchResourceMethodFormatted =
+  (method: string) =>
+  (
+    resource: string,
+    relation: string,
+    handleError: (error: Response) => void,
+    handleLabelFormatting: (data: {
+      text: string;
+      value: string | number;
+      extra?: any;
+    }) => string,
+    user?: {
+      userId: string | number;
+      firstName: string;
+      lastName: string;
+      username?: string;
+    },
+  ) =>
+  async (filterValue = '', page: number, pageSize: number) => {
+    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
+    const queryParams = rison.encode_uri({
+      filter: filterValue,
+      page,
+      page_size: pageSize,
+    });
+    const { json = {} } = await SupersetClient.get({
+      endpoint: `${resourceEndpoint}?q=${queryParams}`,
+    });
+
+    let fetchedLoggedUser = false;
+    const loggedUser = user
+      ? {
+          label: `${user.firstName} ${user.lastName}`,
+          value: user.userId,
+        }
+      : undefined;
+
+    const data: { label: string; value: string | number }[] = [];
+    json?.result
+      ?.filter(({ text }: { text: string }) => text.trim().length > 0)
+      .forEach(
+        ({
+          text,
+          value,
+          extra,
+        }: {
+          text: string;
+          value: string | number;
+          extra?: any;
+        }) => {
+          if (
+            loggedUser &&
+            value === loggedUser.value &&
+            text === loggedUser.label
+          ) {
+            fetchedLoggedUser = true;
+            loggedUser.label = handleLabelFormatting({ text, value, extra });
+          } else {
+            data.push({
+              label: handleLabelFormatting({ text, value, extra }),
+              value,
+            });
+          }
+        },
+      );
+
+    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
+      data.unshift(loggedUser);
+    }
+
+    console.log(data);
+
+    return {
+      data,
+      totalCount: json?.count,
+    };
+  };
+
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Filter[], selectColumns?: string[]) => {
   const params = {
@@ -247,6 +325,8 @@ export const getRecentActivityObjs = (
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
+export const createFetchRelatedFormatted =
+  createFetchResourceMethodFormatted('related');
 
 export function createErrorHandler(
   handleErrorFunc: (

--- a/superset-frontend/src/views/CRUD/utils.tsx
+++ b/superset-frontend/src/views/CRUD/utils.tsx
@@ -125,82 +125,6 @@ const createFetchResourceMethod =
     };
   };
 
-const createFetchResourceMethodFormatted =
-  (method: string) =>
-  (
-    resource: string,
-    relation: string,
-    handleError: (error: Response) => void,
-    handleLabelFormatting: (data: {
-      text: string;
-      value: string | number;
-      extra?: any;
-    }) => string,
-    user?: {
-      userId: string | number;
-      firstName: string;
-      lastName: string;
-      username?: string;
-    },
-  ) =>
-  async (filterValue = '', page: number, pageSize: number) => {
-    const resourceEndpoint = `/api/v1/${resource}/${method}/${relation}`;
-    const queryParams = rison.encode_uri({
-      filter: filterValue,
-      page,
-      page_size: pageSize,
-    });
-    const { json = {} } = await SupersetClient.get({
-      endpoint: `${resourceEndpoint}?q=${queryParams}`,
-    });
-
-    let fetchedLoggedUser = false;
-    const loggedUser = user
-      ? {
-          label: `${user.firstName} ${user.lastName}`,
-          value: user.userId,
-        }
-      : undefined;
-
-    const data: { label: string; value: string | number }[] = [];
-    json?.result
-      ?.filter(({ text }: { text: string }) => text.trim().length > 0)
-      .forEach(
-        ({
-          text,
-          value,
-          extra,
-        }: {
-          text: string;
-          value: string | number;
-          extra?: any;
-        }) => {
-          if (
-            loggedUser &&
-            value === loggedUser.value &&
-            text === loggedUser.label
-          ) {
-            fetchedLoggedUser = true;
-            loggedUser.label = handleLabelFormatting({ text, value, extra });
-          } else {
-            data.push({
-              label: handleLabelFormatting({ text, value, extra }),
-              value,
-            });
-          }
-        },
-      );
-
-    if (loggedUser && (!filterValue || fetchedLoggedUser)) {
-      data.unshift(loggedUser);
-    }
-
-    return {
-      data,
-      totalCount: json?.count,
-    };
-  };
-
 export const PAGE_SIZE = 5;
 const getParams = (filters?: Filter[], selectColumns?: string[]) => {
   const params = {
@@ -323,8 +247,6 @@ export const getRecentActivityObjs = (
 
 export const createFetchRelated = createFetchResourceMethod('related');
 export const createFetchDistinct = createFetchResourceMethod('distinct');
-export const createFetchRelatedFormatted =
-  createFetchResourceMethodFormatted('related');
 
 export function createErrorHandler(
   handleErrorFunc: (

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -206,7 +206,7 @@ class DashboardGetResponseSchema(Schema):
     changed_on = fields.DateTime()
     created_by = fields.Nested(UserSchema(exclude=["username"]))
     charts = fields.List(fields.String(metadata={"description": charts_description}))
-    owners = fields.List(fields.Nested(UserSchema(exclude=["username"])))
+    owners = fields.List(fields.Nested(UserSchema))
     roles = fields.List(fields.Nested(RolesSchema))
     tags = fields.Nested(TagSchema, many=True)
     changed_on_humanized = fields.String(data_key="changed_on_delta_humanized")

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -202,7 +202,7 @@ class DashboardGetResponseSchema(Schema):
         metadata={"description": certification_details_description}
     )
     changed_by_name = fields.String()
-    changed_by = fields.Nested(UserSchema(exclude=["username"]))
+    changed_by = fields.Nested(UserSchema)
     changed_on = fields.DateTime()
     created_by = fields.Nested(UserSchema(exclude=["username"]))
     charts = fields.List(fields.String(metadata={"description": charts_description}))

--- a/superset/reports/api.py
+++ b/superset/reports/api.py
@@ -152,6 +152,7 @@ class ReportScheduleRestApi(BaseSupersetModelRestApi):
         "owners.first_name",
         "owners.id",
         "owners.last_name",
+        "owners.username",
         "recipients.id",
         "recipients.type",
         "timezone",

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -300,7 +300,11 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         }
     """
 
-    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active", "username"]}
+    extra_fields_rel_fields: dict[str, list[str]] = {
+        "owners": ["email", "active", "username"],
+        "changed_by": ["username"],
+        "created_by": ["username"],
+    }
     """
     Declare extra fields for the representation of the Model object::
 
@@ -377,9 +381,10 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         return filters
 
     def _get_text_for_model(self, model: Model, column_name: str) -> str:
-        # Special case for owners, we want to return the full name and username
-        if column_name == "owners":
+        # Handle special cases for owners, changed_by, and created_by
+        if column_name in {"owners", "changed_by", "created_by"}:
             return f"{model.first_name} {model.last_name} ({model.username})"
+
         if column_name in self.text_field_rel_fields:
             model_column_name = self.text_field_rel_fields.get(column_name)
             if model_column_name:

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -300,7 +300,7 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         }
     """
 
-    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active"]}
+    extra_fields_rel_fields: dict[str, list[str]] = {"owners": ["email", "active", "username"]}
     """
     Declare extra fields for the representation of the Model object::
 

--- a/superset/views/base_api.py
+++ b/superset/views/base_api.py
@@ -377,6 +377,9 @@ class BaseSupersetModelRestApi(BaseSupersetApiMixin, ModelRestApi):
         return filters
 
     def _get_text_for_model(self, model: Model, column_name: str) -> str:
+        # Special case for owners, we want to return the full name and username
+        if column_name == "owners":
+            return f"{model.first_name} {model.last_name} ({model.username})"
         if column_name in self.text_field_rel_fields:
             model_column_name = self.text_field_rel_fields.get(column_name)
             if model_column_name:

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -376,13 +376,13 @@ class ApiOwnersTestCaseMixin:
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
             {
-                "extra": {"active": True, "email": "gamma@fab.org"},
-                "text": "gamma user",
+                "extra": {"active": True, "email": "gamma@fab.org", "username": "gamma"},
+                "text": "gamma user (gamma)",
                 "value": 2,
             },
             {
-                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
-                "text": "gamma_sqllab user",
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org", "username": "gamma_sqllab"},
+                "text": "gamma_sqllab user (gamma_sqllab)",
                 "value": 4,
             },
         ]
@@ -403,13 +403,13 @@ class ApiOwnersTestCaseMixin:
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
             {
-                "extra": {"active": True, "email": "gamma@fab.org"},
-                "text": "gamma user",
+                "extra": {"active": True, "email": "gamma@fab.org", "username": "gamma"},
+                "text": "gamma user (gamma)",
                 "value": 2,
             },
             {
-                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
-                "text": "gamma_sqllab user",
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org", "username": "gamma_sqllab"},
+                "text": "gamma_sqllab user (gamma_sqllab)",
                 "value": 4,
             },
         ]

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -289,23 +289,23 @@ class ApiOwnersTestCaseMixin:
         sorted_results = sorted(response["result"], key=lambda value: value["text"])
         expected_results = [
             {
-                "extra": {"active": True, "email": "gamma@fab.org"},
-                "text": "gamma user",
+                "extra": {"active": True, "email": "gamma@fab.org", "username": "gamma"},
+                "text": "gamma user (gamma)",
                 "value": 2,
             },
             {
-                "extra": {"active": True, "email": "gamma2@fab.org"},
-                "text": "gamma2 user",
+                "extra": {"active": True, "email": "gamma2@fab.org", "username": "gamma2"},
+                "text": "gamma2 user (gamma2)",
                 "value": 3,
             },
             {
-                "extra": {"active": True, "email": "gamma_no_csv@fab.org"},
-                "text": "gamma_no_csv user",
+                "extra": {"active": True, "email": "gamma_no_csv@fab.org", "username": "gamma_no_csv"},
+                "text": "gamma_no_csv user (gamma_no_csv)",
                 "value": 6,
             },
             {
-                "extra": {"active": True, "email": "gamma_sqllab@fab.org"},
-                "text": "gamma_sqllab user",
+                "extra": {"active": True, "email": "gamma_sqllab@fab.org", "username": "gamma_sqllab"},
+                "text": "gamma_sqllab user (gamma_sqllab)",
                 "value": 4,
             },
         ]

--- a/tests/integration_tests/base_api_tests.py
+++ b/tests/integration_tests/base_api_tests.py
@@ -212,7 +212,12 @@ class ApiOwnersTestCaseMixin:
         assert rv.status_code == 200
         response = json.loads(rv.data.decode("utf-8"))
         users = db.session.query(security_manager.user_model).all()
-        expected_users = [str(user) for user in users]
+        expected_users = [
+            f"{user.first_name} {user.last_name} ({user.username})"
+            if user.username
+            else str(user)
+            for user in users
+        ]
         assert response["count"] == len(users)
         # This needs to be implemented like this, because ordering varies between
         # postgres and mysql
@@ -238,7 +243,7 @@ class ApiOwnersTestCaseMixin:
             assert rv.status_code == 200
             response = json.loads(rv.data.decode("utf-8"))
             response_users = [result["text"] for result in response["result"]]
-            assert response_users == ["alpha user"]
+            assert response_users == ["alpha user (alpha)"]
 
     def test_get_related_owners_paginated(self):
         """
@@ -260,7 +265,12 @@ class ApiOwnersTestCaseMixin:
         assert len(response["result"]) == min(page_size, len(users))
 
         # make sure all received users are included in the full set of users
-        all_users = [str(user) for user in users]
+        all_users = [
+            f"{user.first_name} {user.last_name} ({user.username})"
+            if user.username
+            else str(user)
+            for user in users
+        ]
         for received_user in [result["text"] for result in response["result"]]:
             assert received_user in all_users
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1727,7 +1727,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         current_dash = [d for d in res if d["id"] == dashboard_id][0]
         self.assertEqual(current_dash["dashboard_title"], "title2")
         self.assertNotIn("username", current_dash["changed_by"].keys())
-        self.assertNotIn("username", current_dash["owners"][0].keys())
+        # Added username in owners object
+        # self.assertNotIn("username", current_dash["owners"][0].keys())
 
         db.session.delete(model)
         db.session.commit()
@@ -1753,7 +1754,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
 
         self.assertEqual(res["dashboard_title"], "title2")
         self.assertNotIn("username", res["changed_by"].keys())
-        self.assertNotIn("username", res["owners"][0].keys())
+        # Added username in owners object
+        # self.assertNotIn("username", res["owners"][0].keys())
 
         db.session.delete(model)
         db.session.commit()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -510,6 +510,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
                         "id": 1,
                         "first_name": "admin",
                         "last_name": "user",
+                        "username": "admin"
                     }
                 ],
                 "roles": [],

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -1754,8 +1754,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         res = json.loads(response.data.decode("utf-8"))["result"]
 
         self.assertEqual(res["dashboard_title"], "title2")
-        self.assertNotIn("username", res["changed_by"].keys())
-        # Added username in owners object
+        # Added username to changed_by and owners
+        # self.assertNotIn("username", res["changed_by"].keys())
         # self.assertNotIn("username", res["owners"][0].keys())
 
         db.session.delete(model)

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -300,10 +300,10 @@ class TestReportSchedulesApi(SupersetTestCase):
         for key in expected_result:
             assert data["result"][key] == expected_result[key]
         # needed because order may vary
-        assert {"first_name": "admin", "id": 1, "last_name": "user", "username": "admin"} in data["result"][
+        assert {"first_name": "admin", "id": 1, "last_name": "user"} in data["result"][
             "owners"
         ]
-        assert {"first_name": "alpha", "id": 5, "last_name": "user", "username": "alpha"} in data["result"][
+        assert {"first_name": "alpha", "id": 5, "last_name": "user"} in data["result"][
             "owners"
         ]
         assert len(data["result"]["owners"]) == 2

--- a/tests/integration_tests/reports/api_tests.py
+++ b/tests/integration_tests/reports/api_tests.py
@@ -300,10 +300,10 @@ class TestReportSchedulesApi(SupersetTestCase):
         for key in expected_result:
             assert data["result"][key] == expected_result[key]
         # needed because order may vary
-        assert {"first_name": "admin", "id": 1, "last_name": "user"} in data["result"][
+        assert {"first_name": "admin", "id": 1, "last_name": "user", "username": "admin"} in data["result"][
             "owners"
         ]
-        assert {"first_name": "alpha", "id": 5, "last_name": "user"} in data["result"][
+        assert {"first_name": "alpha", "id": 5, "last_name": "user", "username": "alpha"} in data["result"][
             "owners"
         ]
         assert len(data["result"]["owners"]) == 2
@@ -381,7 +381,7 @@ class TestReportSchedulesApi(SupersetTestCase):
         assert expected_fields == data_keys
 
         # Assert nested fields
-        expected_owners_fields = ["first_name", "id", "last_name"]
+        expected_owners_fields = ["first_name", "id", "last_name", "username"]
         data_keys = sorted(list(data["result"][0]["owners"][0].keys()))
         assert expected_owners_fields == data_keys
 


### PR DESCRIPTION
### SUMMARY
Return the user's username when querying for dashboard owners. This displays the user's username in the dashboard's owner filter and the dashboard properties access field/dropdown. This helps us distinguish users with the same name, and allows us to search by username. 

The `api/v1/dashboard/related/owners` endpoint was already returning the correct results when filtering by username, but the component filters out the results because the displayed name doesn't actually include the text filter.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

#### Dashboard filters

https://github.com/user-attachments/assets/37bb641f-642e-441c-b071-6bc7b4c320d4

#### Dashboard access

https://github.com/user-attachments/assets/3450f79e-bece-47a6-9cb3-1933712bbc5a

#### Dashboard annotation layers
<img width="515" height="372" alt="Screenshot 2025-07-25 at 2 00 50 PM" src="https://github.com/user-attachments/assets/dd5376e6-384b-4243-ae9b-efee650c9fef" />

#### Dashboard reports

https://github.com/user-attachments/assets/e5ca8590-b528-4bf9-82b0-b2141d6750e0




### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
