### PR TITLE
fix(dashboard): Dashboard relevance score query optimization

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -29,6 +29,7 @@ from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext, ngettext
 from marshmallow import ValidationError
+from sqlalchemy import case, func
 from werkzeug.wrappers import Response as WerkzeugResponse
 from werkzeug.wsgi import FileWrapper
 
@@ -94,7 +95,12 @@ from superset.dashboards.schemas import (
     thumbnail_query_schema,
 )
 from superset.extensions import event_logger
-from superset.models.dashboard import Dashboard
+from superset.models.core import FavStar, FavStarClassName
+from superset.models.dashboard import (
+    Dashboard,
+    DEPRECATED_TITLE_PENALTY,
+    MISSING_TITLE_PENALTY,
+)
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.security.guest_token import GuestUser
 from superset.tasks.thumbnails import (
@@ -348,16 +354,50 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 # Clear any existing ordering
                 query = query.order_by(None)
 
-                # Apply custom ordering based on relevance_score
+                # Join with FavStar table to get favorite counts
+                query = query.outerjoin(
+                    FavStar,
+                    (FavStar.obj_id == Dashboard.id) &
+                    (FavStar.class_name == FavStarClassName.DASHBOARD)
+                )
+
+                # Apply ordering with GROUP BY to handle the JOIN properly
+                query = query.group_by(Dashboard.id)
+
+                favorite_count = func.coalesce(func.count(FavStar.id), 0)
+
+                # Calculate title penalties (same logic as in the model)
+                title_penalty = (
+                    case(
+                        [
+                            (Dashboard.dashboard_title.is_(None), MISSING_TITLE_PENALTY),
+                            (func.lower(func.trim(Dashboard.dashboard_title)).like('[ untitled ]%'), MISSING_TITLE_PENALTY),
+                        ],
+                        else_=0,
+                    )
+                    + case(
+                        [
+                            (func.lower(func.trim(Dashboard.dashboard_title)).like('[deprecated]%'), DEPRECATED_TITLE_PENALTY),
+                            (func.lower(func.trim(Dashboard.dashboard_title)).like('%[deprecated]'), DEPRECATED_TITLE_PENALTY),
+                            (func.lower(func.trim(Dashboard.dashboard_title)).like('(deprecated)%'), DEPRECATED_TITLE_PENALTY),
+                            (func.lower(func.trim(Dashboard.dashboard_title)).like('%(deprecated)'), DEPRECATED_TITLE_PENALTY),
+                        ],
+                        else_=0,
+                    )
+                )
+
+                # Calculate relevance score (same logic as in the model)
+                relevance_score = favorite_count - title_penalty
+
                 if order_direction == "desc":
                     return query.order_by(
-                        Dashboard.relevance_score.desc(),
+                        relevance_score.desc(),
                         Dashboard.published.desc(),
                         Dashboard.dashboard_title.asc()
                     )
                 else:
                     return query.order_by(
-                        Dashboard.relevance_score.asc(),
+                        relevance_score.asc(),
                         Dashboard.published.asc(),
                         Dashboard.dashboard_title.asc()
                     )

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -35,10 +35,6 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
-    case,
-    func,
-    or_,
-    select,
 )
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -360,7 +356,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
         return {"all_tabs": all_tabs, "tab_tree": tab_tree}
 
-    @hybrid_property
+    @property
     def relevance_score(self) -> float:
         """
         Returns a relevance score for the dashboard based on its favorite count.
@@ -387,36 +383,6 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
         return score
 
-    @relevance_score.expression
-    def relevance_score(cls):
-        """
-        SQL expression for relevance score in queries
-        """
-        return (
-            # Start with favorite count
-            select(func.count(FavStar.id))
-            .where(FavStar.obj_id == cls.id)
-            .where(FavStar.class_name == 'Dashboard')
-            .scalar_subquery()
-            # Subtract penalty for missing titles
-            - case(
-                [
-                    (cls.dashboard_title.is_(None), MISSING_TITLE_PENALTY),
-                    (func.lower(func.trim(cls.dashboard_title)).like('[ untitled ]%'), MISSING_TITLE_PENALTY),
-                ],
-                else_=0,
-            )
-            # Subtract penalty for deprecated titles
-            - case(
-                [
-                    (func.lower(func.trim(cls.dashboard_title)).like('[deprecated]%'), DEPRECATED_TITLE_PENALTY),
-                    (func.lower(func.trim(cls.dashboard_title)).like('%[deprecated]'), DEPRECATED_TITLE_PENALTY),
-                    (func.lower(func.trim(cls.dashboard_title)).like('(deprecated)%'), DEPRECATED_TITLE_PENALTY),
-                    (func.lower(func.trim(cls.dashboard_title)).like('%(deprecated)'), DEPRECATED_TITLE_PENALTY),
-                ],
-                else_=0,
-            )
-        )
 
     def update_thumbnail(self) -> None:
         cache_dashboard_thumbnail.delay(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To calculate relevance score for a dashboard, we need to perform a join with the FavStar table. When loading a list of dashboards sorted by relevance score, if the join is inside the model, we're performing 1 join per dashboard.

Move the join outside of the model so this only has to be performed once instead of N times.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
