### PR TITLE
fix(dashboard): Fix slow query when sorting dashboards by relevance score

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -354,17 +354,21 @@ class DashboardRestApi(BaseSupersetModelRestApi):
                 # Clear any existing ordering
                 query = query.order_by(None)
 
-                # Join with FavStar table to get favorite counts
+                # Create a pre-aggregated subquery that counts favorites per dashboard
+                favstar_counts = db.session.query(
+                    FavStar.obj_id.label('dashboard_id'),
+                    func.count(FavStar.id).label('favorite_count')
+                ).filter(
+                    FavStar.class_name == FavStarClassName.DASHBOARD
+                ).group_by(FavStar.obj_id).subquery()
+
+                # Join with the pre-aggregated favorite counts
                 query = query.outerjoin(
-                    FavStar,
-                    (FavStar.obj_id == Dashboard.id) &
-                    (FavStar.class_name == FavStarClassName.DASHBOARD)
+                    favstar_counts,
+                    favstar_counts.c.dashboard_id == Dashboard.id
                 )
 
-                # Apply ordering with GROUP BY to handle the JOIN properly
-                query = query.group_by(Dashboard.id)
-
-                favorite_count = func.coalesce(func.count(FavStar.id), 0)
+                favorite_count = func.coalesce(favstar_counts.c.favorite_count, 0)
 
                 # Calculate title penalties (same logic as in the model)
                 title_penalty = (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Optimize the query to sort dashboards by relevance once more
- The previous [PR](https://github.com/pinterest/superset/pull/78) created an outer join with the `FavStar` table before grouping and counting records. 
- This PR groups and counts the favorites before joining to the dashboards table

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
