### PR TITLE
feat(dashboard): Backend changes to enable syncing dashboard and chart owners

### DIFF
--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -749,6 +749,19 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             return self.response_400(message=error.messages)
         try:
             changed_model = UpdateDashboardCommand(pk, item).run()
+
+            # Sync chart owners after the dashboard has been updated
+            try:
+                changed_model.sync_dashboard_chart_owners()
+            except Exception as sync_error:
+                # Log the sync error
+                logger.warning(
+                    "Failed to sync chart owners for dashboard %s: %s",
+                    changed_model.id,
+                    str(sync_error),
+                    exc_info=True,
+                )
+
             last_modified_time = changed_model.changed_on.replace(
                 microsecond=0
             ).timestamp()

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -148,6 +148,7 @@ class DashboardJSONMetadataSchema(Schema):
     # used to configure dashboard_metadata cache strategy
     # (will be deprecated once TAGGING_SYSTEM feature is complete)
     cache_warmup_schedule = fields.Str(allow_none=True)
+    auto_sync_chart_owners = fields.Boolean(allow_none=True)
 
     @pre_load
     def remove_show_native_filters(  # pylint: disable=unused-argument

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -483,21 +483,38 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         A chart will have its own owners updated if the owners of the dashboard
         and chart have mutual owners.
         """
+        logger.debug("Syncing dashboard chart owners for dashboard %s", self.id)
         if not self.auto_sync_chart_owners:
             return
 
         dashboard_owner_ids = {owner.id for owner in self.owners}
+        logger.debug("Dashboard owner IDs: %s", dashboard_owner_ids)
 
         for slice in self.slices:
             slice_owner_ids = {owner.id for owner in slice.owners}
+            logger.debug("Slice %s owner IDs: %s", slice.id, slice_owner_ids)
 
             if not bool(dashboard_owner_ids & slice_owner_ids):
+                logger.debug(
+                    "No mutual owners found for dashboard %s and slice %s",
+                    self.id,
+                    slice.id,
+                )
                 continue
 
             if dashboard_owner_ids.issubset(slice_owner_ids):
+                logger.debug(
+                    "Slice %s already has all dashboard owners, skipping sync",
+                    slice.id,
+                )   
                 continue
 
-            slice.owners = [set(slice.owners) | set(self.owners)]
+            slice.owners = list(set(slice.owners) | set(self.owners))
+            logger.debug(
+                "Updated slice %s owners to include dashboard owners: %s",
+                slice.id,
+                [owner.id for owner in slice.owners],
+            )
 
         db.session.commit()
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -499,6 +499,8 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
             slice.owners = set(slice.owners) | set(self.owners)
 
+        db.session.commit()
+
     @property
     def auto_sync_chart_owners(self) -> bool:
         return json.loads(self.params).get("auto_sync_chart_owners", False)

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -483,38 +483,21 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         A chart will have its own owners updated if the owners of the dashboard
         and chart have mutual owners.
         """
-        logger.debug("Syncing dashboard chart owners for dashboard %s", self.id)
         if not self.auto_sync_chart_owners:
             return
 
         dashboard_owner_ids = {owner.id for owner in self.owners}
-        logger.debug("Dashboard owner IDs: %s", dashboard_owner_ids)
 
         for slice in self.slices:
             slice_owner_ids = {owner.id for owner in slice.owners}
-            logger.debug("Slice %s owner IDs: %s", slice.id, slice_owner_ids)
 
             if not bool(dashboard_owner_ids & slice_owner_ids):
-                logger.debug(
-                    "No mutual owners found for dashboard %s and slice %s",
-                    self.id,
-                    slice.id,
-                )
                 continue
 
             if dashboard_owner_ids.issubset(slice_owner_ids):
-                logger.debug(
-                    "Slice %s already has all dashboard owners, skipping sync",
-                    slice.id,
-                )   
                 continue
 
             slice.owners = list(set(slice.owners) | set(self.owners))
-            logger.debug(
-                "Updated slice %s owners to include dashboard owners: %s",
-                slice.id,
-                [owner.id for owner in slice.owners],
-            )
 
         db.session.commit()
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -144,7 +144,6 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
     certification_details = Column(Text)
     json_metadata = Column(utils.MediumText())
     slug = Column(String(255), unique=True)
-    auto_sync_chart_owners = False  # TODO: read from db - Column(Boolean, default=False)
     slices: list[Slice] = relationship(
         Slice, secondary=dashboard_slices, backref="dashboards"
     )
@@ -495,11 +494,20 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
             if not bool(dashboard_owner_ids & slice_owner_ids):
                 continue
 
-            if dashboard_owner_ids == slice_owner_ids:
+            if dashboard_owner_ids.issubset(slice_owner_ids):
                 continue
 
-            new_owners = set(slice.owners) | set(self.owners)
-            slice.owners = list(new_owners)
+            slice.owners = set(slice.owners) | set(self.owners)
+
+    @property
+    def auto_sync_chart_owners(self) -> bool:
+        return json.loads(self.params).get("auto_sync_chart_owners", False)
+
+    @auto_sync_chart_owners.setter
+    def auto_sync_chart_owners(self, value: bool) -> None:
+        metadata = json.loads(self.params or "{}")
+        metadata["auto_sync_chart_owners"] = value
+        self.params = json.dumps(metadata)
 
 
 def is_uuid(value: str | int) -> bool:

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -144,6 +144,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
     certification_details = Column(Text)
     json_metadata = Column(utils.MediumText())
     slug = Column(String(255), unique=True)
+    auto_sync_chart_owners = False  # TODO: read from db - Column(Boolean, default=False)
     slices: list[Slice] = relationship(
         Slice, secondary=dashboard_slices, backref="dashboards"
     )
@@ -475,6 +476,30 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         """
 
         security_manager.raise_for_access(dashboard=self)
+
+    def sync_dashboard_chart_owners(self) -> None:
+        """
+        Add the owners of this dashboard to be owners of each chart
+        when auto_sync_chart_owners is enabled.
+        A chart will have its own owners updated if the owners of the dashboard
+        and chart have mutual owners.
+        """
+        if not self.auto_sync_chart_owners:
+            return
+
+        dashboard_owner_ids = {owner.id for owner in self.owners}
+
+        for slice in self.slices:
+            slice_owner_ids = {owner.id for owner in slice.owners}
+
+            if not bool(dashboard_owner_ids & slice_owner_ids):
+                continue
+
+            if dashboard_owner_ids == slice_owner_ids:
+                continue
+
+            new_owners = set(slice.owners) | set(self.owners)
+            slice.owners = list(new_owners)
 
 
 def is_uuid(value: str | int) -> bool:

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -497,7 +497,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
             if dashboard_owner_ids.issubset(slice_owner_ids):
                 continue
 
-            slice.owners = set(slice.owners) | set(self.owners)
+            slice.owners = [set(slice.owners) | set(self.owners)]
 
         db.session.commit()
 

--- a/tests/integration_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/integration_tests/dashboards/sync_chart_owners_tests.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+from superset import db
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from tests.integration_tests.base_tests import SupersetTestCase
+
+
+class TestSyncDashboardChartOwners(SupersetTestCase):
+    def test_sync_dashboard_chart_owners(self):
+        """
+        Test the complete sync flow with real database objects
+        """
+        with self.app.app_context():
+            # Create dashboard with auto_sync enabled
+            dashboard = Dashboard(
+                dashboard_title="Test Dashboard",
+                json_metadata='{"auto_sync_chart_owners": true}'
+            )
+
+            # Create users (owners)
+            dashboard_owner = self.get_user("admin")
+            chart_owner = self.get_user("gamma")
+
+            # Create a chart
+            chart = Slice(
+                slice_name="Test Chart",
+                datasource_id=1,
+                datasource_type="table"
+            )
+
+            # Set up relationships
+            dashboard.owners = [dashboard_owner]
+            chart.owners = [chart_owner, dashboard_owner]  # Mutual owner
+            dashboard.slices = [chart]
+
+            # Save to database
+            db.session.add(dashboard)
+            db.session.add(chart)
+            db.session.commit()
+
+            # Verify initial state
+            assert len(chart.owners) == 2
+
+            # Add another owner to dashboard
+            new_dashboard_owner = self.get_user("alpha")
+            dashboard.owners.append(new_dashboard_owner)
+            db.session.commit()
+
+            # Execute sync
+            dashboard.sync_dashboard_chart_owners()
+            db.session.commit()
+
+            # Verify chart now has the new dashboard owner
+            assert len(chart.owners) == 3
+            assert set(chart.owners) == {
+                dashboard_owner,
+                chart_owner,
+                new_dashboard_owner
+            }

--- a/tests/integration_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/integration_tests/dashboards/sync_chart_owners_tests.py
@@ -72,3 +72,8 @@ class TestSyncDashboardChartOwners(SupersetTestCase):
                 chart_owner,
                 new_dashboard_owner
             }
+
+            # Clean up
+            db.session.delete(dashboard)
+            db.session.delete(chart)
+            db.session.commit()

--- a/tests/integration_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/integration_tests/dashboards/sync_chart_owners_tests.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import pytest
 from superset import db
 from superset.models.dashboard import Dashboard
 from superset.models.slice import Slice

--- a/tests/unit_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/unit_tests/dashboards/sync_chart_owners_tests.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import pytest
 from unittest.mock import MagicMock
 from superset.models.dashboard import Dashboard

--- a/tests/unit_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/unit_tests/dashboards/sync_chart_owners_tests.py
@@ -1,0 +1,273 @@
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset import db
+
+
+def test_sync_disabled_when_auto_sync_not_set() -> None:
+    """
+    Test that sync does nothing when auto_sync_chart_owners is not in metadata
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{}'
+
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1]
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = [owner2]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    # Assert - slice owners should contain only the original owner
+    assert len(slice_mock.owners) == 1
+    assert slice_mock.owners[0].id == 1
+
+    # Dashboard owner should NOT be added
+    assert not any(owner.id == 2 for owner in slice_mock.owners)
+
+
+def test_sync_disabled_when_auto_sync_false() -> None:
+    """
+    Test that sync does nothing when auto_sync_chart_owners is False
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": false}'
+
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1]
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = [owner2]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    # Assert - slice owners should contain only the original owner
+    assert len(slice_mock.owners) == 1
+    assert slice_mock.owners[0].id == 1
+
+    # Dashboard owner should NOT be added
+    assert not any(owner.id == 2 for owner in slice_mock.owners)
+
+
+def test_sync_skips_charts_with_no_mutual_owners() -> None:
+    """
+    Test that charts with no mutual owners are skipped
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+    owner3 = MagicMock(id=3)
+    owner4 = MagicMock(id=4)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1, owner2]
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = [owner3, owner4]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    # Assert - slice owners should contain only the original owner
+    assert len(slice_mock.owners) == 2
+    assert slice_mock.owners == [owner1, owner2]
+    assert dashboard.owners == [owner3, owner4]
+
+
+def test_sync_skips_charts_that_already_have_all_dashboard_owners() -> None:
+    """
+    Test that charts already containing all dashboard owners are skipped
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+    owner3 = MagicMock(id=3)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1, owner2, owner3]
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = [owner1, owner2]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    # Slice should be skipped and owners attribute should never have been accessed for modification
+    assert len(slice_mock.method_calls) == 0
+    assert len(slice_mock.owners) == 3  # Should remain unchanged
+    assert len(dashboard.owners) == 2  # Dashboard owners should remain unchanged
+
+
+def test_sync_adds_dashboard_owners_to_charts_with_mutual_owners() -> None:
+    """
+    Test that dashboard owners are added to charts with mutual owners
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+    owner3 = MagicMock(id=3)
+    owner4 = MagicMock(id=4)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1, owner4]
+    slice_mock.id = 1
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = [owner1, owner2, owner3]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    expected_owners = {owner1, owner2, owner3, owner4}
+    assert set(slice_mock.owners) == expected_owners
+
+
+def test_sync_handles_multiple_charts_differently() -> None:
+    """
+    Test that sync handles multiple charts based on their individual
+    owner sets
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    # Create mock owners
+    owner1 = MagicMock(id=1)
+    owner2 = MagicMock(id=2)
+    owner3 = MagicMock(id=3)
+    owner4 = MagicMock(id=4)
+
+    dashboard.owners = [owner1, owner2]
+
+    # Slice 1: Has mutual owner, should be synced
+    slice1 = MagicMock()
+    slice1.owners = [owner1, owner3]
+
+    # Slice 2: No mutual owners, should be skipped
+    slice2 = MagicMock()
+    slice2.owners = [owner3, owner4]
+
+    # Slice 3: Already has all dashboard owners, should be skipped
+    slice3 = MagicMock()
+    slice3.owners = [owner1, owner2, owner3]
+
+    dashboard.slices = [slice1, slice2, slice3]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    # Slice 1 should have dashboard owners added
+    assert len(slice1.owners) == 3
+    assert set(slice1.owners) == {owner1, owner2, owner3}
+
+    # Slice 2 should remain unchanged
+    assert len(slice2.owners) == 2
+    assert set(slice2.owners) == {owner3, owner4}
+
+    # Slice 3 should remain unchanged
+    assert len(slice3.owners) == 3
+    assert set(slice3.owners) == {owner1, owner2, owner3}
+
+
+def test_sync_with_empty_dashboard_owners() -> None:
+    """
+    Test sync behavior when dashboard has no owners
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner1 = MagicMock(id=1)
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner1]
+    slice_mock.id = 1
+
+    dashboard.slices = [slice_mock]
+    dashboard.owners = []
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+    assert len(slice_mock.method_calls) == 0
+    assert len(slice_mock.owners) == 1  # Should remain unchanged
+
+
+def test_sync_with_empty_slices() -> None:
+    """
+    Test sync behavior when dashboard has no slices
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner1 = MagicMock(id=1)
+
+    dashboard.slices = []
+    dashboard.owners = [owner1]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+
+    assert len(dashboard.owners) == 1  # Should remain unchanged
+    assert len(dashboard.slices) == 0  # Should remain unchanged
+
+
+def test_sync_with_malformed_json_metadata() -> None:
+    """
+    Test sync behavior when json_metadata is malformed
+    """
+    # Setup
+    dashboard = Dashboard()
+    dashboard.json_metadata = 'invalid'
+
+    # Execute - should raise JSONDecodeError or handle gracefully
+    with pytest.raises(Exception):  # Could be JSONDecodeError or ValueError
+        dashboard.sync_dashboard_chart_owners()
+
+
+# @patch('superset.models.dashboard.db.session')
+def test_sync_commits_changes_to_database(mocker) -> None:
+    """
+    Test that sync changes are committed to the database
+    """
+    # Setup
+    mock_session = mocker.patch("superset.models.dashboard.db.session")
+
+    dashboard = Dashboard()
+    dashboard.json_metadata = '{"auto_sync_chart_owners": true}'
+
+    owner = MagicMock(id=1)
+    dashboard.owners = [owner]
+
+    slice_mock = MagicMock()
+    slice_mock.owners = [owner, MagicMock(id=2)]
+    dashboard.slices = [slice_mock]
+
+    # Execute
+    dashboard.sync_dashboard_chart_owners()
+    mock_session.commit.assert_called_once()
+
+    # Assert - slice owners should now include the dashboard owner
+    assert len(slice_mock.owners) == 2
+    assert owner in slice_mock.owners

--- a/tests/unit_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/unit_tests/dashboards/sync_chart_owners_tests.py
@@ -260,7 +260,6 @@ def test_sync_with_malformed_json_metadata() -> None:
         dashboard.sync_dashboard_chart_owners()
 
 
-# @patch('superset.models.dashboard.db.session')
 def test_sync_commits_changes_to_database(mocker) -> None:
     """
     Test that sync changes are committed to the database

--- a/tests/unit_tests/dashboards/sync_chart_owners_tests.py
+++ b/tests/unit_tests/dashboards/sync_chart_owners_tests.py
@@ -1,8 +1,6 @@
 import pytest
-from unittest.mock import Mock, MagicMock, patch
+from unittest.mock import MagicMock
 from superset.models.dashboard import Dashboard
-from superset.models.slice import Slice
-from superset import db
 
 
 def test_sync_disabled_when_auto_sync_not_set() -> None:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds `auto_sync_chart_owners` param to the `json_metadata`. When `auto_sync_chart_owners` is `True`, chart owners are updated to include all dashboard owners if there is at least one mutual owner between the dashboard and chart.

### VIDEO

https://github.com/user-attachments/assets/f080d52a-ca7e-4b05-86c0-06c936930e4e


#### Logs during sync operation
```
DEBUG:superset.models.dashboard:sync chart owners: True
DEBUG:superset.models.dashboard:Dashboard owners: {1, 3}
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 76
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 77
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 69
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 70
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 71
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 72
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 73
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 74
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 75
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 78
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 79
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 80
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 81
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 82
DEBUG:superset.models.dashboard:Slice 91 owners: {3}
DEBUG:superset.models.dashboard:Updating slice 91 owners from {3} to {1, 3}
DEBUG:superset.models.dashboard:Slice 90 owners: {3}
DEBUG:superset.models.dashboard:Updating slice 90 owners from {3} to {1, 3}
DEBUG:superset.models.dashboard:Slice 89 owners: {2}
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 89
DEBUG:superset.models.dashboard:Slice 88 owners: {1}
DEBUG:superset.models.dashboard:Updating slice 88 owners from {1} to {1, 3}
DEBUG:superset.models.dashboard:Slice 87 owners: {2}
DEBUG:superset.models.dashboard:No mutual owners between dashboard 6 and slice 87
DEBUG:superset.models.dashboard:Slice 86 owners: {1, 2}
DEBUG:superset.models.dashboard:Updating slice 86 owners from {1, 2} to {1, 2, 3}
DEBUG:superset.models.dashboard:Slice 85 owners: {1, 3}
DEBUG:superset.models.dashboard:Slice 85 already has all dashboard 6 owners, skipping
DEBUG:superset.models.dashboard:Slice 84 owners: {2, 3}
DEBUG:superset.models.dashboard:Updating slice 84 owners from {2, 3} to {1, 2, 3}
DEBUG:superset.models.dashboard:Slice 92 owners: {3}
DEBUG:superset.models.dashboard:Updating slice 92 owners from {3} to {1, 3}
DEBUG:superset.models.dashboard:Slice 83 owners: {1, 2, 3}
DEBUG:superset.models.dashboard:Slice 83 already has all dashboard 6 owners, skipping
```


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Added unit and integration tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
