### PR TITLE
feat(dashboard): Add checkbox to sync chart owners in dashboard properties modal

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -234,7 +234,6 @@ test('should render - FeatureFlag disabled', async () => {
   expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: 'Colors' })).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: 'Advanced' })).toBeInTheDocument();
-
   expect(
     screen.getByRole('heading', { name: 'Certification' }),
   ).toBeInTheDocument();
@@ -267,7 +266,9 @@ test('should render - FeatureFlag enabled', async () => {
     await screen.findByTestId('dashboard-edit-properties-form'),
   ).toBeInTheDocument();
 
-  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(
+    screen.getByRole('dialog', { name: 'Dashboard properties' }),
+  ).toBeInTheDocument();
 
   expect(
     screen.getByRole('heading', { name: 'Basic information' }),
@@ -622,19 +623,11 @@ describe('sync chart owners', () => {
     expect(tooltip).not.toBeInTheDocument();
   });
 
-  it('should not be checked if metadata is empty', async () => {
+  it('should not be checked if metadata does not have param', async () => {
     spyIsFeatureEnabled.mockReturnValue(true);
 
     const props = createProps();
-    const propsWithDashboardInfo = {
-      ...props,
-      dashboardInfo: {
-        ...dashboardInfo,
-        metadata: '{}',
-      },
-    };
-
-    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    render(<PropertiesModal {...props} />, {
       useRedux: true,
     });
 
@@ -684,16 +677,7 @@ describe('sync chart owners', () => {
     spyIsFeatureEnabled.mockReturnValue(true);
 
     const props = createProps();
-    const propsWithDashboardInfo = {
-      ...props,
-      dashboardInfo: {
-        ...dashboardInfo,
-        metadata: { auto_sync_chart_owners: false },
-      },
-    };
-
-    fetchMock.resetHistory();
-    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    render(<PropertiesModal {...props} />, {
       useRedux: true,
     });
 
@@ -756,6 +740,64 @@ describe('sync chart owners', () => {
     await waitFor(() => {
       expect(checkbox).toBeChecked();
       expect(fetchMock.calls(mockChartsEndpoint).length).toBe(1);
+    });
+  });
+
+  test('should update when metadata changes', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
+
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: { auto_sync_chart_owners: false },
+      },
+    };
+
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
+
+    // Wait for the checkbox to have its final state (not checked)
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+    // Ensure the API call was not made
+    expect(fetchMock.called(mockChartsEndpoint)).toBe(false);
+
+    userEvent.click(screen.getByRole('button', { name: 'Advanced' }));
+
+    const container = screen.getByTestId('dashboard-edit-properties-form');
+
+    const metadataInput = container.getElementsByClassName(
+      'ace_text-input',
+    )[0] as HTMLTextAreaElement;
+
+    await waitFor(() => {
+      expect(metadataInput).toBeInTheDocument();
+    });
+
+    // Clear and set new content using ACE API
+    const aceEditor = container.querySelector('.ace_editor') as any;
+    const editor = (window as any).ace.edit(aceEditor);
+    editor.setValue('{"auto_sync_chart_owners": true}', 1);
+    editor.clearSelection();
+
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+      expect(fetchMock.calls(mockChartsEndpoint).length).toBe(1);
+    });
+
+    editor.setValue('invalid json', 1);
+    editor.clearSelection();
+
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
     });
   });
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import { render, screen, waitFor, within } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
 import userEvent from '@testing-library/user-event';
 import * as ColorSchemeControlWrapper from 'src/dashboard/components/ColorSchemeControlWrapper';
@@ -93,6 +93,62 @@ fetchMock.get(
   },
 );
 
+fetchMock.get('http://localhost/api/v1/dashboard/26/charts', {
+  body: {
+    result: [
+      {
+        id: 369,
+        slice_name: 'Vaccine Candidates per Country',
+        slice_name_override: 'Map of Vaccine Candidates',
+        owners: [
+          {
+            id: 369,
+            first_name: 'foo',
+            last_name: 'bar',
+            username: 'foobar',
+          },
+        ],
+      },
+      {
+        id: 314,
+        slice_name: 'Vaccine Candidates per Country',
+        slice_name_override: 'Map of Vaccine Candidates',
+      },
+      {
+        id: 351,
+        slice_name: 'Vaccine Candidates per Phase',
+        slice_name_override: 'Vaccine Candidates per Phase',
+      },
+      {
+        id: 312,
+        slice_name: 'Vaccine Candidates per Phase',
+        slice_name_override: 'Vaccine Candidates per Phase',
+      },
+      {
+        id: 325,
+        slice_name: 'Vaccine Candidates per Country & Stage',
+        slice_name_override: 'Heatmap of Countries & Clinical Stages',
+      },
+      {
+        id: 358,
+        slice_name: 'Filtering Vaccines',
+        slice_name_override: 'Filter Box of Vaccines',
+      },
+      {
+        id: 371,
+
+        slice_name: 'Vaccine Candidates per Country & Stage',
+        slice_name_override: 'Sunburst of Country & Clinical Stages',
+      },
+      {
+        id: 364,
+        slice_name: 'Vaccine Candidates per Approach & Stage',
+        slice_name_override: 'Heatmap of Approaches & Clinical Stages',
+      },
+    ],
+  },
+});
+
 const dashboardInfo = {
   certified_by: 'John Doe',
   certification_details: 'Sample certification',
@@ -112,7 +168,7 @@ const dashboardInfo = {
   css: '',
   dashboard_title: 'COVID Vaccine Dashboard',
   id: 26,
-  metadata: mockedJsonMetadata,
+  metadata: JSON.parse(mockedJsonMetadata),
   owners: [],
   position_json:
     '{"CHART-63bEuxjDMJ": {"children": [], "id": "CHART-63bEuxjDMJ", "meta": {"chartId": 369, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Map of Vaccine Candidates", "uuid": "ddc91df6-fb40-4826-bdca-16b85af1c024", "width": 7}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-F-fkth0Dnv": {"children": [], "id": "CHART-F-fkth0Dnv", "meta": {"chartId": 314, "height": 76, "sliceName": "Vaccine Candidates per Country", "sliceNameOverride": "Treemap of Vaccine Candidates per Country", "uuid": "e2f5a8a7-feb0-4f79-bc6b-01fe55b98b3c", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zvw7luvEL"], "type": "CHART"}, "CHART-RjD_ygqtwH": {"children": [], "id": "CHART-RjD_ygqtwH", "meta": {"chartId": 351, "height": 59, "sliceName": "Vaccine Candidates per Phase", "sliceNameOverride": "Vaccine Candidates per Phase", "uuid": "30b73c65-85e7-455f-bb24-801bb0cdc670", "width": 2}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-aGfmWtliqA": {"children": [], "id": "CHART-aGfmWtliqA", "meta": {"chartId": 312, "height": 59, "sliceName": "Vaccine Candidates per Phase", "uuid": "392f293e-0892-4316-bd41-c927b65606a4", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-dCUpAcPsji": {"children": [], "id": "CHART-dCUpAcPsji", "meta": {"chartId": 325, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Heatmap of Countries & Clinical Stages", "uuid": "cd111331-d286-4258-9020-c7949a109ed2", "width": 4}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-eirDduqb1A": {"children": [], "id": "CHART-eirDduqb1A", "meta": {"chartId": 358, "height": 59, "sliceName": "Filtering Vaccines", "sliceNameOverride": "Filter Box of Vaccines", "uuid": "c29381ce-0e99-4cf3-bf0f-5f55d6b94176", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "CHART"}, "CHART-fYo7IyvKZQ": {"children": [], "id": "CHART-fYo7IyvKZQ", "meta": {"chartId": 371, "height": 82, "sliceName": "Vaccine Candidates per Country & Stage", "sliceNameOverride": "Sunburst of Country & Clinical Stages", "uuid": "f69c556f-15fe-4a82-a8bb-69d5b6954123", "width": 5}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "CHART-j4hUvP5dDD": {"children": [], "id": "CHART-j4hUvP5dDD", "meta": {"chartId": 364, "height": 82, "sliceName": "Vaccine Candidates per Approach & Stage", "sliceNameOverride": "Heatmap of Approaches & Clinical Stages", "uuid": "0c953c84-0c9a-418d-be9f-2894d2a2cee0", "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-zhOlQLQnB"], "type": "CHART"}, "DASHBOARD_VERSION_KEY": "v2", "GRID_ID": {"children": [], "id": "GRID_ID", "parents": ["ROOT_ID"], "type": "GRID"}, "HEADER_ID": {"id": "HEADER_ID", "meta": {"text": "COVID Vaccine Dashboard"}, "type": "HEADER"}, "MARKDOWN-VjQQ5SFj5v": {"children": [], "id": "MARKDOWN-VjQQ5SFj5v", "meta": {"code": "# COVID-19 Vaccine Dashboard\\n\\nEverywhere you look, you see negative news about COVID-19. This is to be expected; it\'s been a brutal year and this disease is no joke. This dashboard hopes to use visualization to inject some optimism about the coming return to normalcy we enjoyed before 2020! There\'s lots to be optimistic about:\\n\\n- the sheer volume of attempts to fund the R&D needed to produce and bring an effective vaccine to market\\n- the large number of countries involved in at least one vaccine candidate (and the diversity of economic status of these countries)\\n- the diversity of vaccine approaches taken\\n- the fact that 2 vaccines have already been approved (and a hundreds of thousands of patients have already been vaccinated)\\n\\n### The Dataset\\n\\nThis dashboard is powered by data maintained by the Millken Institute ([link to dataset](https://airtable.com/shrSAi6t5WFwqo3GM/tblEzPQS5fnc0FHYR/viwDBH7b6FjmIBX5x?blocks=bipZFzhJ7wHPv7x9z)). We researched each vaccine candidate and added our own best guesses for the country responsible for each vaccine effort.\\n\\n_Note that this dataset was last updated on 12/23/2020_.\\n\\n", "height": 59, "width": 3}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ", "ROW-xSeNAspgw"], "type": "MARKDOWN"}, "ROOT_ID": {"children": ["TABS-wUKya7eQ0Z"], "id": "ROOT_ID", "type": "ROOT"}, "ROW-xSeNAspgw": {"children": ["MARKDOWN-VjQQ5SFj5v", "CHART-aGfmWtliqA", "CHART-RjD_ygqtwH", "CHART-eirDduqb1A"], "id": "ROW-xSeNAspgw", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zhOlQLQnB": {"children": ["CHART-j4hUvP5dDD", "CHART-dCUpAcPsji", "CHART-fYo7IyvKZQ"], "id": "ROW-zhOlQLQnB", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "ROW-zvw7luvEL": {"children": ["CHART-63bEuxjDMJ", "CHART-F-fkth0Dnv"], "id": "ROW-zvw7luvEL", "meta": {"0": "ROOT_ID", "background": "BACKGROUND_TRANSPARENT"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z", "TAB-BCIJF4NvgQ"], "type": "ROW"}, "TAB-BCIJF4NvgQ": {"children": ["ROW-xSeNAspgw", "ROW-zvw7luvEL", "ROW-zhOlQLQnB"], "id": "TAB-BCIJF4NvgQ", "meta": {"text": "Overview"}, "parents": ["ROOT_ID", "TABS-wUKya7eQ0Z"], "type": "TAB"}, "TABS-wUKya7eQ0Z": {"children": ["TAB-BCIJF4NvgQ"], "id": "TABS-wUKya7eQ0Z", "meta": {}, "parents": ["ROOT_ID"], "type": "TABS"}}',
@@ -168,32 +224,52 @@ test('should render - FeatureFlag disabled', async () => {
     await screen.findByTestId('dashboard-edit-properties-form'),
   ).toBeInTheDocument();
 
-  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  const modal = screen.getByRole('dialog', { name: 'Dashboard properties' });
+  expect(modal).toBeInTheDocument();
 
   expect(
-    screen.getByRole('heading', { name: 'Basic information' }),
+    within(modal).getByRole('heading', { name: 'Basic information' }),
   ).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Colors' })).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Advanced' })).toBeInTheDocument();
   expect(
-    screen.getByRole('heading', { name: 'Certification' }),
+    within(modal).getByRole('heading', { name: 'Access' }),
   ).toBeInTheDocument();
-  expect(screen.getAllByRole('heading')).toHaveLength(5);
+  expect(
+    within(modal).getByRole('heading', { name: 'Colors' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('heading', { name: 'Advanced' }),
+  ).toBeInTheDocument();
 
-  expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Advanced' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
-  expect(screen.getAllByRole('button')).toHaveLength(4);
+  expect(
+    within(modal).getByRole('heading', { name: 'Certification' }),
+  ).toBeInTheDocument();
+  expect(within(modal).getAllByRole('heading')).toHaveLength(5);
 
-  expect(screen.getAllByRole('textbox')).toHaveLength(4);
-  expect(screen.getByRole('combobox')).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Close' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Advanced' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Cancel' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Save' }),
+  ).toBeInTheDocument();
+  expect(within(modal).getAllByRole('button')).toHaveLength(4);
+
+  expect(within(modal).getAllByRole('textbox')).toHaveLength(4);
+  expect(within(modal).getByRole('combobox')).toBeInTheDocument();
 
   expect(spyColorSchemeControlWrapper).toBeCalledWith(
     expect.objectContaining({ colorScheme: 'supersetColors' }),
     {},
   );
+
+  expect(
+    within(modal).getByTestId('sync-chart-owners-control'),
+  ).toBeInTheDocument();
 });
 
 test('should render - FeatureFlag enabled', async () => {
@@ -206,35 +282,52 @@ test('should render - FeatureFlag enabled', async () => {
     await screen.findByTestId('dashboard-edit-properties-form'),
   ).toBeInTheDocument();
 
-  expect(
-    screen.getByRole('dialog', { name: 'Dashboard properties' }),
-  ).toBeInTheDocument();
+  const modal = screen.getByRole('dialog', { name: 'Dashboard properties' });
+  expect(modal).toBeInTheDocument();
 
   expect(
-    screen.getByRole('heading', { name: 'Basic information' }),
+    within(modal).getByRole('heading', { name: 'Basic information' }),
   ).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
-  expect(screen.getByRole('heading', { name: 'Advanced' })).toBeInTheDocument();
   expect(
-    screen.getByRole('heading', { name: 'Certification' }),
+    within(modal).getByRole('heading', { name: 'Access' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('heading', { name: 'Advanced' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('heading', { name: 'Certification' }),
   ).toBeInTheDocument();
   // Tags will be included since isFeatureFlag always returns true in this test
-  expect(screen.getByRole('heading', { name: 'Tags' })).toBeInTheDocument();
-  expect(screen.getAllByRole('heading')).toHaveLength(5);
+  expect(
+    within(modal).getByRole('heading', { name: 'Tags' }),
+  ).toBeInTheDocument();
+  expect(within(modal).getAllByRole('heading')).toHaveLength(5);
 
-  expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Advanced' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
-  expect(screen.getAllByRole('button')).toHaveLength(4);
+  expect(
+    within(modal).getByRole('button', { name: 'Close' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Advanced' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Cancel' }),
+  ).toBeInTheDocument();
+  expect(
+    within(modal).getByRole('button', { name: 'Save' }),
+  ).toBeInTheDocument();
+  expect(within(modal).getAllByRole('button')).toHaveLength(4);
 
-  expect(screen.getAllByRole('textbox')).toHaveLength(4);
-  expect(screen.getAllByRole('combobox')).toHaveLength(3);
+  expect(within(modal).getAllByRole('textbox')).toHaveLength(4);
+  expect(within(modal).getAllByRole('combobox')).toHaveLength(3);
 
   expect(spyColorSchemeControlWrapper).toBeCalledWith(
     expect.objectContaining({ colorScheme: 'supersetColors' }),
     {},
   );
+
+  expect(
+    within(modal).getByTestId('sync-chart-owners-control'),
+  ).toBeInTheDocument();
 });
 
 test('should open advance', async () => {
@@ -475,4 +568,133 @@ test('should not show roles without dashboard rbac editor permissions', async ()
   });
 
   expect(screen.queryByText('Roles')).not.toBeInTheDocument();
+});
+
+test('auto sync chart owners should be checked if true in metadata', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  const props = createProps();
+  const propsWithDashboardInfo = {
+    ...props,
+    dashboardInfo: {
+      ...dashboardInfo,
+      metadata: { auto_sync_chart_owners: true },
+    },
+  };
+
+  render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    useRedux: true,
+  });
+
+  // Wait for API call to complete
+  await waitFor(() => {
+    expect(
+      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
+    ).toBe(true);
+  });
+
+  const checkbox = await within(
+    screen.getByTestId('sync-chart-owners-control'),
+  ).findByRole('checkbox');
+
+  expect(checkbox).toBeChecked();
+
+  const tooltip = within(
+    screen.getByTestId('sync-chart-owners-control'),
+  ).getByLabelText(
+    'You do not have permission to update the following charts',
+    { exact: false },
+  );
+
+  expect(tooltip).toBeInTheDocument();
+});
+
+test('auto sync chart owners should not be checked if false in metadata', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  const props = createProps();
+  const propsWithDashboardInfo = {
+    ...props,
+    dashboardInfo: {
+      ...dashboardInfo,
+      metadata: { auto_sync_chart_owners: false },
+    },
+  };
+
+  render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    useRedux: true,
+  });
+
+  // Wait for API call to complete
+  await waitFor(() => {
+    expect(
+      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
+    ).toBe(true);
+  });
+
+  const checkbox = await within(
+    screen.getByTestId('sync-chart-owners-control'),
+  ).findByRole('checkbox');
+
+  expect(checkbox).not.toBeChecked();
+});
+
+test('auto sync chart owners should not be checked if metadata is empty', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  const props = createProps();
+  const propsWithDashboardInfo = {
+    ...props,
+    dashboardInfo: {
+      ...dashboardInfo,
+      metadata: '{}',
+    },
+  };
+
+  render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    useRedux: true,
+  });
+
+  // Wait for API call to complete
+  await waitFor(() => {
+    expect(
+      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
+    ).toBe(true);
+  });
+
+  const checkbox = await within(
+    screen.getByTestId('sync-chart-owners-control'),
+  ).findByRole('checkbox');
+
+  expect(checkbox).not.toBeChecked();
+});
+
+test('auto sync chart owners should not be checked if not a boolean in metadata', async () => {
+  spyIsFeatureEnabled.mockReturnValue(true);
+
+  const props = createProps();
+  const propsWithDashboardInfo = {
+    ...props,
+    dashboardInfo: {
+      ...dashboardInfo,
+      metadata: { auto_sync_chart_owners: 'test' },
+    },
+  };
+
+  render(<PropertiesModal {...propsWithDashboardInfo} />, {
+    useRedux: true,
+  });
+
+  // Wait for API call to complete
+  await waitFor(() => {
+    expect(
+      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
+    ).toBe(true);
+  });
+
+  const checkbox = await within(
+    screen.getByTestId('sync-chart-owners-control'),
+  ).findByRole('checkbox');
+
+  expect(checkbox).not.toBeChecked();
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -226,52 +226,35 @@ test('should render - FeatureFlag disabled', async () => {
     await screen.findByTestId('dashboard-edit-properties-form'),
   ).toBeInTheDocument();
 
-  const modal = screen.getByRole('dialog', { name: 'Dashboard properties' });
-  expect(modal).toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
 
   expect(
-    within(modal).getByRole('heading', { name: 'Basic information' }),
+    screen.getByRole('heading', { name: 'Basic information' }),
   ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('heading', { name: 'Access' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('heading', { name: 'Colors' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('heading', { name: 'Advanced' }),
-  ).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Colors' })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Advanced' })).toBeInTheDocument();
 
   expect(
-    within(modal).getByRole('heading', { name: 'Certification' }),
+    screen.getByRole('heading', { name: 'Certification' }),
   ).toBeInTheDocument();
-  expect(within(modal).getAllByRole('heading')).toHaveLength(5);
+  expect(screen.getAllByRole('heading')).toHaveLength(5);
 
-  expect(
-    within(modal).getByRole('button', { name: 'Close' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Advanced' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Cancel' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Save' }),
-  ).toBeInTheDocument();
-  expect(within(modal).getAllByRole('button')).toHaveLength(4);
+  expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Advanced' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  expect(screen.getAllByRole('button')).toHaveLength(4);
 
-  expect(within(modal).getAllByRole('textbox')).toHaveLength(4);
-  expect(within(modal).getByRole('combobox')).toBeInTheDocument();
+  expect(screen.getAllByRole('textbox')).toHaveLength(4);
+  expect(screen.getByRole('combobox')).toBeInTheDocument();
 
   expect(spyColorSchemeControlWrapper).toBeCalledWith(
     expect.objectContaining({ colorScheme: 'supersetColors' }),
     {},
   );
 
-  expect(
-    within(modal).getByTestId('sync-chart-owners-control'),
-  ).toBeInTheDocument();
+  expect(screen.getByTestId('sync-chart-owners-control')).toBeInTheDocument();
 });
 
 test('should render - FeatureFlag enabled', async () => {
@@ -284,52 +267,35 @@ test('should render - FeatureFlag enabled', async () => {
     await screen.findByTestId('dashboard-edit-properties-form'),
   ).toBeInTheDocument();
 
-  const modal = screen.getByRole('dialog', { name: 'Dashboard properties' });
-  expect(modal).toBeInTheDocument();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
 
   expect(
-    within(modal).getByRole('heading', { name: 'Basic information' }),
+    screen.getByRole('heading', { name: 'Basic information' }),
   ).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Access' })).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: 'Advanced' })).toBeInTheDocument();
   expect(
-    within(modal).getByRole('heading', { name: 'Access' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('heading', { name: 'Advanced' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('heading', { name: 'Certification' }),
+    screen.getByRole('heading', { name: 'Certification' }),
   ).toBeInTheDocument();
   // Tags will be included since isFeatureFlag always returns true in this test
-  expect(
-    within(modal).getByRole('heading', { name: 'Tags' }),
-  ).toBeInTheDocument();
-  expect(within(modal).getAllByRole('heading')).toHaveLength(5);
+  expect(screen.getByRole('heading', { name: 'Tags' })).toBeInTheDocument();
+  expect(screen.getAllByRole('heading')).toHaveLength(5);
 
-  expect(
-    within(modal).getByRole('button', { name: 'Close' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Advanced' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Cancel' }),
-  ).toBeInTheDocument();
-  expect(
-    within(modal).getByRole('button', { name: 'Save' }),
-  ).toBeInTheDocument();
-  expect(within(modal).getAllByRole('button')).toHaveLength(4);
+  expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Advanced' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  expect(screen.getAllByRole('button')).toHaveLength(4);
 
-  expect(within(modal).getAllByRole('textbox')).toHaveLength(4);
-  expect(within(modal).getAllByRole('combobox')).toHaveLength(3);
+  expect(screen.getAllByRole('textbox')).toHaveLength(4);
+  expect(screen.getAllByRole('combobox')).toHaveLength(3);
 
   expect(spyColorSchemeControlWrapper).toBeCalledWith(
     expect.objectContaining({ colorScheme: 'supersetColors' }),
     {},
   );
 
-  expect(
-    within(modal).getByTestId('sync-chart-owners-control'),
-  ).toBeInTheDocument();
+  expect(screen.getByTestId('sync-chart-owners-control')).toBeInTheDocument();
 });
 
 test('should open advance', async () => {

--- a/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/PropertiesModal.test.tsx
@@ -32,6 +32,8 @@ const spyColorSchemeControlWrapper = jest.spyOn(
 const mockedJsonMetadata =
   '{"timed_refresh_immune_slices": [], "expanded_slices": {}, "refresh_frequency": 0, "default_filters": "{}", "color_scheme": "supersetColors", "label_colors": {"0": "#D3B3DA", "1": "#9EE5E5", "0. Pre-clinical": "#1FA8C9", "2. Phase II or Combined I/II": "#454E7C", "1. Phase I": "#5AC189", "3. Phase III": "#FF7F44", "4. Authorized": "#666666", "root": "#1FA8C9", "Protein subunit": "#454E7C", "Phase II": "#5AC189", "Pre-clinical": "#FF7F44", "Phase III": "#666666", "Phase I": "#E04355", "Phase I/II": "#FCC700", "Inactivated virus": "#A868B7", "Virus-like particle": "#3CCCCB", "Replicating bacterial vector": "#A38F79", "DNA-based": "#8FD3E4", "RNA-based vaccine": "#A1A6BD", "Authorized": "#ACE1C4", "Non-replicating viral vector": "#FEC0A1", "Replicating viral vector": "#B2B2B2", "Unknown": "#EFA1AA", "Live attenuated virus": "#FDE380", "COUNT(*)": "#D1C6BC"}, "filter_scopes": {"358": {"Country_Name": {"scope": ["ROOT_ID"], "immune": []}, "Product_Category": {"scope": ["ROOT_ID"], "immune": []}, "Clinical Stage": {"scope": ["ROOT_ID"], "immune": []}}}}';
 
+const mockChartsEndpoint = 'http://localhost/api/v1/dashboard/26/charts';
+
 spyColorSchemeControlWrapper.mockImplementation(
   () => (<div>ColorSchemeControlWrapper</div>) as any,
 );
@@ -93,7 +95,7 @@ fetchMock.get(
   },
 );
 
-fetchMock.get('http://localhost/api/v1/dashboard/26/charts', {
+fetchMock.get(mockChartsEndpoint, {
   body: {
     result: [
       {
@@ -570,131 +572,224 @@ test('should not show roles without dashboard rbac editor permissions', async ()
   expect(screen.queryByText('Roles')).not.toBeInTheDocument();
 });
 
-test('auto sync chart owners should be checked if true in metadata', async () => {
-  spyIsFeatureEnabled.mockReturnValue(true);
-
-  const props = createProps();
-  const propsWithDashboardInfo = {
-    ...props,
-    dashboardInfo: {
-      ...dashboardInfo,
-      metadata: { auto_sync_chart_owners: true },
-    },
-  };
-
-  render(<PropertiesModal {...propsWithDashboardInfo} />, {
-    useRedux: true,
+describe('sync chart owners', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  // Wait for API call to complete
-  await waitFor(() => {
-    expect(
-      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
-    ).toBe(true);
+  afterEach(() => {
+    fetchMock.resetHistory();
   });
 
-  const checkbox = await within(
-    screen.getByTestId('sync-chart-owners-control'),
-  ).findByRole('checkbox');
+  it('should be checked if enabled in metadata', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
 
-  expect(checkbox).toBeChecked();
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: { auto_sync_chart_owners: true },
+      },
+    };
 
-  const tooltip = within(
-    screen.getByTestId('sync-chart-owners-control'),
-  ).getByLabelText(
-    'You do not have permission to update the following charts',
-    { exact: false },
-  );
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
 
-  expect(tooltip).toBeInTheDocument();
-});
+    // Wait for API call to complete
+    await waitFor(() => {
+      expect(fetchMock.called(mockChartsEndpoint)).toBe(true);
+    });
 
-test('auto sync chart owners should not be checked if false in metadata', async () => {
-  spyIsFeatureEnabled.mockReturnValue(true);
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
 
-  const props = createProps();
-  const propsWithDashboardInfo = {
-    ...props,
-    dashboardInfo: {
-      ...dashboardInfo,
-      metadata: { auto_sync_chart_owners: false },
-    },
-  };
+    expect(checkbox).toBeChecked();
 
-  render(<PropertiesModal {...propsWithDashboardInfo} />, {
-    useRedux: true,
+    const tooltip = within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).getByLabelText(
+      'You do not have permission to update the following charts',
+      { exact: false },
+    );
+
+    expect(tooltip).toBeInTheDocument();
   });
 
-  // Wait for API call to complete
-  await waitFor(() => {
-    expect(
-      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
-    ).toBe(true);
+  it('should not be checked if disabled in metadata', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
+
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: { auto_sync_chart_owners: false },
+      },
+    };
+
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
+
+    // Wait for the checkbox to have its final state (not checked)
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    // Ensure the API call was not made
+    expect(fetchMock.called(mockChartsEndpoint)).toBe(false);
+
+    const tooltip = within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).queryByLabelText(
+      'You do not have permission to update the following charts',
+      { exact: false },
+    );
+
+    expect(tooltip).not.toBeInTheDocument();
   });
 
-  const checkbox = await within(
-    screen.getByTestId('sync-chart-owners-control'),
-  ).findByRole('checkbox');
+  it('should not be checked if metadata is empty', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
 
-  expect(checkbox).not.toBeChecked();
-});
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: '{}',
+      },
+    };
 
-test('auto sync chart owners should not be checked if metadata is empty', async () => {
-  spyIsFeatureEnabled.mockReturnValue(true);
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
 
-  const props = createProps();
-  const propsWithDashboardInfo = {
-    ...props,
-    dashboardInfo: {
-      ...dashboardInfo,
-      metadata: '{}',
-    },
-  };
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
 
-  render(<PropertiesModal {...propsWithDashboardInfo} />, {
-    useRedux: true,
+    // Wait for the checkbox to have its final state (not checked)
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    // Ensure the API call was not made
+    expect(fetchMock.called(mockChartsEndpoint)).toBe(false);
   });
 
-  // Wait for API call to complete
-  await waitFor(() => {
-    expect(
-      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
-    ).toBe(true);
+  it('should not be checked if value is not a boolean in metadata', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
+
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: { auto_sync_chart_owners: 'test' },
+      },
+    };
+
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
+
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
+
+    // Wait for the checkbox to have its final state (not checked)
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    // Ensure the API call was not made
+    expect(fetchMock.called(mockChartsEndpoint)).toBe(false);
   });
 
-  const checkbox = await within(
-    screen.getByTestId('sync-chart-owners-control'),
-  ).findByRole('checkbox');
+  it('should defer charts API call until checkbox is clicked', async () => {
+    spyIsFeatureEnabled.mockReturnValue(true);
 
-  expect(checkbox).not.toBeChecked();
-});
+    const props = createProps();
+    const propsWithDashboardInfo = {
+      ...props,
+      dashboardInfo: {
+        ...dashboardInfo,
+        metadata: { auto_sync_chart_owners: false },
+      },
+    };
 
-test('auto sync chart owners should not be checked if not a boolean in metadata', async () => {
-  spyIsFeatureEnabled.mockReturnValue(true);
+    fetchMock.resetHistory();
+    render(<PropertiesModal {...propsWithDashboardInfo} />, {
+      useRedux: true,
+    });
 
-  const props = createProps();
-  const propsWithDashboardInfo = {
-    ...props,
-    dashboardInfo: {
-      ...dashboardInfo,
-      metadata: { auto_sync_chart_owners: 'test' },
-    },
-  };
+    const checkbox = await within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
 
-  render(<PropertiesModal {...propsWithDashboardInfo} />, {
-    useRedux: true,
+    // Wait for the checkbox to have its final state (not checked)
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+    });
+
+    // Ensure the API call was not made
+    expect(fetchMock.called(mockChartsEndpoint)).toBe(false);
+
+    let tooltip = within(
+      screen.getByTestId('sync-chart-owners-control'),
+    ).queryByLabelText(
+      'You do not have permission to update the following charts',
+      { exact: false },
+    );
+
+    expect(tooltip).not.toBeInTheDocument();
+
+    userEvent.click(checkbox);
+
+    // Wait for API call to complete
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+      expect(fetchMock.calls(mockChartsEndpoint).length).toBe(1);
+
+      tooltip = within(
+        screen.getByTestId('sync-chart-owners-control'),
+      ).queryByLabelText(
+        'You do not have permission to update the following charts',
+        { exact: false },
+      );
+
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).not.toBeChecked();
+      expect(fetchMock.calls(mockChartsEndpoint).length).toBe(1);
+
+      tooltip = within(
+        screen.getByTestId('sync-chart-owners-control'),
+      ).queryByLabelText(
+        'You do not have permission to update the following charts',
+        { exact: false },
+      );
+
+      expect(tooltip).not.toBeInTheDocument();
+    });
+
+    userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).toBeChecked();
+      expect(fetchMock.calls(mockChartsEndpoint).length).toBe(1);
+    });
   });
-
-  // Wait for API call to complete
-  await waitFor(() => {
-    expect(
-      fetchMock.called('http://localhost/api/v1/dashboard/26/charts'),
-    ).toBe(true);
-  });
-
-  const checkbox = await within(
-    screen.getByTestId('sync-chart-owners-control'),
-  ).findByRole('checkbox');
-
-  expect(checkbox).not.toBeChecked();
 });

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
@@ -75,7 +75,7 @@ describe('SyncChartOwnersControl', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  it('unsupported chart list gets truncated singular', async () => {
+  it('truncates unsupported chart list to 1 singular', async () => {
     const rendered = render(setup({ dashboardOwnerIds: [1] }));
 
     const tooltip = await rendered.findByLabelText(
@@ -85,7 +85,7 @@ describe('SyncChartOwnersControl', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  it('unsupported chart list gets truncated plural', async () => {
+  it('truncates unsupported chart list to 2 plural', async () => {
     const rendered = render(setup({ dashboardOwnerIds: [] }));
 
     const tooltip = await rendered.findByLabelText(
@@ -95,7 +95,7 @@ describe('SyncChartOwnersControl', () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  it('does not show tooltip when no unsupported charts', () => {
+  it('does not show tooltip when there are no unsupported charts', () => {
     const rendered = render(
       setup({
         dashboardOwnerIds: [1, 2, 3, 4, 5],

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
@@ -17,13 +17,15 @@
  * under the License.
  */
 import { render } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/react';
 
 import SyncChartOwnersControl, {
   SyncChartOwnersControlProps,
 } from 'src/dashboard/components/PropertiesModal/SyncChartOwnersControl';
 
 const props: SyncChartOwnersControlProps = {
-  autoSyncChartsEnabled: false,
+  autoSyncChartsEnabled: true,
   onChange: jest.fn(),
   dashboardOwnerIds: [1, 2, 3],
   chartInfoMap: {
@@ -43,7 +45,9 @@ describe('SyncChartOwnersControl', () => {
   it('renders a checkbox', async () => {
     const rendered = render(setup());
 
-    const checkbox = await rendered.findByRole('checkbox');
+    const checkbox = await within(
+      rendered.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
     const label = rendered.getByText('Add dashboard owners to all charts.');
 
     expect(checkbox).toBeInTheDocument();
@@ -52,15 +56,17 @@ describe('SyncChartOwnersControl', () => {
 
   it('calls onChange when checkbox is clicked', async () => {
     const onChange = jest.fn();
-    const rendered = render(setup({ onChange }));
-    const checkbox = await rendered.findByRole('checkbox');
+    const rendered = render(setup({ autoSyncChartsEnabled: false, onChange }));
 
-    checkbox?.click();
+    const checkbox = await within(
+      rendered.getByTestId('sync-chart-owners-control'),
+    ).findByRole('checkbox');
+    await userEvent.click(checkbox);
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
   it('shows a tooltip for unsupported charts', async () => {
-    const rendered = render(setup({ autoSyncChartsEnabled: true }));
+    const rendered = render(setup());
 
     const tooltip = await rendered.findByLabelText(
       'You do not have permission to update the following charts: Chart 4, Chart 5',
@@ -70,9 +76,7 @@ describe('SyncChartOwnersControl', () => {
   });
 
   it('unsupported chart list gets truncated singular', async () => {
-    const rendered = render(
-      setup({ autoSyncChartsEnabled: true, dashboardOwnerIds: [1] }),
-    );
+    const rendered = render(setup({ dashboardOwnerIds: [1] }));
 
     const tooltip = await rendered.findByLabelText(
       'You do not have permission to update the following charts: Chart 2, Chart 3, Chart 4, and 1 other',
@@ -82,9 +86,7 @@ describe('SyncChartOwnersControl', () => {
   });
 
   it('unsupported chart list gets truncated plural', async () => {
-    const rendered = render(
-      setup({ autoSyncChartsEnabled: true, dashboardOwnerIds: [] }),
-    );
+    const rendered = render(setup({ dashboardOwnerIds: [] }));
 
     const tooltip = await rendered.findByLabelText(
       'You do not have permission to update the following charts: Chart 1, Chart 2, Chart 3, and 2 others',
@@ -96,10 +98,19 @@ describe('SyncChartOwnersControl', () => {
   it('does not show tooltip when no unsupported charts', () => {
     const rendered = render(
       setup({
-        autoSyncChartsEnabled: true,
         dashboardOwnerIds: [1, 2, 3, 4, 5],
       }),
     );
+
+    const tooltip = rendered.queryByLabelText(
+      'You do not have permission to update the following charts:',
+      { selector: 'span' },
+    );
+    expect(tooltip).not.toBeInTheDocument();
+  });
+
+  it('does not show tooltip when autoSyncChartsEnabled is false', () => {
+    const rendered = render(setup({ autoSyncChartsEnabled: false }));
 
     const tooltip = rendered.queryByLabelText(
       'You do not have permission to update the following charts:',

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from 'spec/helpers/testing-library';
+
+import SyncChartOwnersControl, {
+  SyncChartOwnersControlProps,
+} from 'src/dashboard/components/PropertiesModal/SyncChartOwnersControl';
+
+const props: SyncChartOwnersControlProps = {
+  autoSyncChartsEnabled: false,
+  onChange: jest.fn(),
+  dashboardOwnerIds: [1, 2, 3],
+  chartInfoMap: {
+    1: { id: 1, name: 'Chart 1', ownerIds: [1] },
+    2: { id: 2, name: 'Chart 2', ownerIds: [2] },
+    3: { id: 3, name: 'Chart 3', ownerIds: [3] },
+    4: { id: 4, name: 'Chart 4', ownerIds: [4] },
+    5: { id: 5, name: 'Chart 5', ownerIds: [5] },
+  },
+};
+
+const setup = (overrides?: any) => (
+  <SyncChartOwnersControl {...props} {...overrides} />
+);
+
+describe('SyncChartOwnersControl', () => {
+  it('renders a checkbox', async () => {
+    const rendered = render(setup());
+
+    const checkbox = await rendered.findByRole('checkbox');
+    const label = rendered.getByText('Add dashboard owners to all charts.');
+
+    expect(checkbox).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
+  });
+
+  it('calls onChange when checkbox is clicked', async () => {
+    const onChange = jest.fn();
+    const rendered = render(setup({ onChange }));
+    const checkbox = await rendered.findByRole('checkbox');
+
+    checkbox?.click();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows a tooltip for unsupported charts', async () => {
+    const rendered = render(setup({ autoSyncChartsEnabled: true }));
+
+    const tooltip = await rendered.findByLabelText(
+      'You do not have permission to update the following charts: Chart 4, Chart 5',
+      { selector: 'span' },
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('unsupported chart list gets truncated singular', async () => {
+    const rendered = render(
+      setup({ autoSyncChartsEnabled: true, dashboardOwnerIds: [1] }),
+    );
+
+    const tooltip = await rendered.findByLabelText(
+      'You do not have permission to update the following charts: Chart 2, Chart 3, Chart 4, and 1 other',
+      { selector: 'span' },
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('unsupported chart list gets truncated plural', async () => {
+    const rendered = render(
+      setup({ autoSyncChartsEnabled: true, dashboardOwnerIds: [] }),
+    );
+
+    const tooltip = await rendered.findByLabelText(
+      'You do not have permission to update the following charts: Chart 1, Chart 2, Chart 3, and 2 others',
+      { selector: 'span' },
+    );
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it('does not show tooltip when no unsupported charts', () => {
+    const rendered = render(
+      setup({
+        autoSyncChartsEnabled: true,
+        dashboardOwnerIds: [1, 2, 3, 4, 5],
+      }),
+    );
+
+    const tooltip = rendered.queryByLabelText(
+      'You do not have permission to update the following charts:',
+      { selector: 'span' },
+    );
+    expect(tooltip).not.toBeInTheDocument();
+  });
+});

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -44,7 +44,12 @@ const SyncChartOwnersControl = ({
     const unsupportedChartNames = Object.values(chartInfoMap)
       .filter(chartInfo => {
         const chartOwnerSet = new Set(chartInfo.ownerIds);
-        return chartOwnerSet.intersection(dashboardOwnerIdsSet).size === 0;
+        for (const id of chartOwnerSet) {
+          if (dashboardOwnerIdsSet.has(id)) {
+            return false;
+          }
+        }
+        return true;
       })
       .map(chartInfo => chartInfo.name)
       .sort((a, b) => a.localeCompare(b));
@@ -71,29 +76,29 @@ const SyncChartOwnersControl = ({
   const showTooltip = autoSyncChartsEnabled && tooltipText.length > 0;
 
   return (
-    <>
+    <div data-test="sync-chart-owners-control">
       <Checkbox
         aria-checked={autoSyncChartsEnabled}
-        aria-labelledby="sync-chart-owners-control"
+        // aria-labelledby is not being forwarded to the checkbox component.
+        // data-test selector isn't being rendered by the checkbox span.
+        // Wrap this in a div to find this checkbox in tests.
         checked={autoSyncChartsEnabled}
         onChange={onChange}
         style={{ marginRight: '8px' }}
       />
-      <span>
-        <span
-          aria-label={t('Add dashboard owners to all charts.')}
-          id="sync-chart-owners-control"
-          style={{ marginRight: '4px' }}
-        >
-          {t('Add dashboard owners to all charts.')}
-        </span>
-        {showTooltip && (
-          <span aria-label={tooltipText}>
-            <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
-          </span>
-        )}
+      <span
+        aria-label={t('Add dashboard owners to all charts.')}
+        id="sync-chart-owners-control"
+        style={{ marginRight: '4px' }}
+      >
+        {t('Add dashboard owners to all charts.')}
       </span>
-    </>
+      {showTooltip && (
+        <span aria-label={tooltipText}>
+          <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
+        </span>
+      )}
+    </div>
   );
 };
 export default SyncChartOwnersControl;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -63,7 +63,7 @@ const SyncChartOwnersControl = ({
       );
     }
 
-    return `You do not have permission to update the owners of the following charts: ${chartsToShow.join(
+    return `You do not have permission to update the following charts: ${chartsToShow.join(
       ', ',
     )}`;
   }, [chartInfoMap, dashboardOwnerIdsSet]);
@@ -78,16 +78,13 @@ const SyncChartOwnersControl = ({
         style={{ marginRight: '8px' }}
       />
       <span>
-        <span style={{ marginRight: '4px' }}>{t('Sync chart owners')}</span>
+        <span style={{ marginRight: '4px' }}>
+          {t('Add dashboard owners to all charts.')}
+        </span>
         {showTooltip && (
           <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
         )}
       </span>
-      <p className="help-block">
-        {t(
-          'Update owners of all charts in this dashboard to include dashboard owners.',
-        )}
-      </p>
     </>
   );
 };

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -20,9 +20,9 @@ import Checkbox from 'src/components/Checkbox';
 import { t } from '@superset-ui/core';
 import { useMemo } from 'react';
 import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
-import { ChartInfo } from '.';
+import { ChartInfo } from 'src/dashboard/components/PropertiesModal';
 
-type SyncChartOwnersControlProps = {
+export type SyncChartOwnersControlProps = {
   autoSyncChartsEnabled: boolean;
   onChange: (value: boolean) => void;
   dashboardOwnerIds: number[];
@@ -73,16 +73,24 @@ const SyncChartOwnersControl = ({
   return (
     <>
       <Checkbox
+        aria-checked={autoSyncChartsEnabled}
+        aria-labelledby="sync-chart-owners-control"
         checked={autoSyncChartsEnabled}
         onChange={onChange}
         style={{ marginRight: '8px' }}
       />
       <span>
-        <span style={{ marginRight: '4px' }}>
+        <span
+          aria-label={t('Add dashboard owners to all charts.')}
+          id="sync-chart-owners-control"
+          style={{ marginRight: '4px' }}
+        >
           {t('Add dashboard owners to all charts.')}
         </span>
         {showTooltip && (
-          <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
+          <span aria-label={tooltipText}>
+            <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
+          </span>
         )}
       </span>
     </>

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -18,6 +18,8 @@
  */
 import Checkbox from 'src/components/Checkbox';
 import { t } from '@superset-ui/core';
+import { useMemo } from 'react';
+import WarningIconWithTooltip from 'src/components/WarningIconWithTooltip';
 import { ChartInfo } from '.';
 
 type SyncChartOwnersControlProps = {
@@ -32,20 +34,61 @@ const SyncChartOwnersControl = ({
   onChange,
   dashboardOwnerIds,
   chartInfoMap,
-}: SyncChartOwnersControlProps) => (
-  <>
-    <Checkbox
-      checked={autoSyncChartsEnabled}
-      onChange={onChange}
-      style={{ marginRight: '8px' }}
-    />
-    <span>{t('Sync chart owners')}</span>
-    <p className="help-block">
-      {t(
-        'Update owners of all charts in this dashboard to include dashboard owners.',
-      )}
-    </p>
-  </>
-);
+}: SyncChartOwnersControlProps) => {
+  const dashboardOwnerIdsSet = useMemo(
+    () => new Set(dashboardOwnerIds),
+    [dashboardOwnerIds],
+  );
 
+  const tooltipText = useMemo(() => {
+    const unsupportedChartNames = Object.values(chartInfoMap)
+      .filter(chartInfo => {
+        const chartOwnerSet = new Set(chartInfo.ownerIds);
+        return chartOwnerSet.intersection(dashboardOwnerIdsSet).size === 0;
+      })
+      .map(chartInfo => chartInfo.name)
+      .sort((a, b) => a.localeCompare(b));
+
+    if (unsupportedChartNames.length === 0) {
+      return '';
+    }
+
+    let chartsToShow = unsupportedChartNames;
+
+    if (unsupportedChartNames.length > 3) {
+      chartsToShow = chartsToShow.slice(0, 3);
+      const remainingCount = unsupportedChartNames.length - 3;
+      chartsToShow.push(
+        `and ${remainingCount === 1 ? '1 other' : `${remainingCount} others`}`,
+      );
+    }
+
+    return `You do not have permission to update the owners of the following charts: ${chartsToShow.join(
+      ', ',
+    )}`;
+  }, [chartInfoMap, dashboardOwnerIdsSet]);
+
+  const showTooltip = autoSyncChartsEnabled && tooltipText.length > 0;
+
+  return (
+    <>
+      <Checkbox
+        checked={autoSyncChartsEnabled}
+        onChange={onChange}
+        style={{ marginRight: '8px' }}
+      />
+      <span>
+        <span style={{ marginRight: '4px' }}>{t('Sync chart owners')}</span>
+        {showTooltip && (
+          <WarningIconWithTooltip size="s" warningMarkdown={tooltipText} />
+        )}
+      </span>
+      <p className="help-block">
+        {t(
+          'Update owners of all charts in this dashboard to include dashboard owners.',
+        )}
+      </p>
+    </>
+  );
+};
 export default SyncChartOwnersControl;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import Checkbox from 'src/components/Checkbox';
+import { t } from '@superset-ui/core';
+import { ChartInfo } from '.';
+
+type SyncChartOwnersControlProps = {
+  autoSyncChartsEnabled: boolean;
+  onChange: (value: boolean) => void;
+  dashboardOwnerIds: number[];
+  chartInfoMap: Record<number, ChartInfo>;
+};
+
+const SyncChartOwnersControl = ({
+  autoSyncChartsEnabled,
+  onChange,
+  dashboardOwnerIds,
+  chartInfoMap,
+}: SyncChartOwnersControlProps) => (
+  <>
+    <Checkbox
+      checked={autoSyncChartsEnabled}
+      onChange={onChange}
+      style={{ marginRight: '8px' }}
+    />
+    <span>{t('Sync chart owners')}</span>
+    <p className="help-block">
+      {t(
+        'Update owners of all charts in this dashboard to include dashboard owners.',
+      )}
+    </p>
+  </>
+);
+
+export default SyncChartOwnersControl;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -52,6 +52,7 @@ import {
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
 import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
+import Checkbox from 'src/components/Checkbox';
 
 const StyledFormItem = styled(FormItem)`
   margin-bottom: 0;
@@ -508,6 +509,33 @@ const PropertiesModal = ({
     );
   };
 
+  const getSyncChartsCheckbox = () => {
+    const jsonMetadataObj = getJsonMetadata();
+    const hasSyncChartsEnabled =
+      jsonMetadataObj?.auto_sync_chart_owners || false;
+
+    return (
+      <>
+        <Checkbox
+          checked={hasSyncChartsEnabled}
+          onChange={e => {
+            const jsonMetadataObj = getJsonMetadata();
+            jsonMetadataObj.auto_sync_chart_owners = e;
+            setJsonMetadata(jsonStringify(jsonMetadataObj));
+          }}
+          style={{ marginRight: '8px' }}
+        />
+        <span>{t('Sync chart owners')}</span>
+
+        <p className="help-block">
+          {t(
+            'Update owners of all charts in this dashboard to include dashboard owners.',
+          )}
+        </p>
+      </>
+    );
+  };
+
   useEffect(() => {
     if (show) {
       if (!currentDashboardInfo) {
@@ -630,9 +658,12 @@ const PropertiesModal = ({
             </p>
           </Col>
         </Row>
-        {isFeatureEnabled(FeatureFlag.DashboardRbac) && canAccessRoles
-          ? getRowsWithRoles()
-          : getRowsWithoutRoles()}
+        <>
+          {isFeatureEnabled(FeatureFlag.DashboardRbac) && canAccessRoles
+            ? getRowsWithRoles()
+            : getRowsWithoutRoles()}
+          {getSyncChartsCheckbox()}
+        </>
         <Row>
           <Col xs={24} md={24}>
             <h3>{t('Certification')}</h3>

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -530,8 +530,6 @@ const PropertiesModal = ({
         const nextVal = val ?? false;
         const jsonMetadataObj = getJsonMetadata();
         jsonMetadataObj.auto_sync_chart_owners = nextVal;
-
-        setAutoSyncChartsEnabled(nextVal);
         setJsonMetadata(jsonStringify(jsonMetadataObj));
       }}
       dashboardOwnerIds={owners.map(owner => owner.id)}
@@ -601,7 +599,7 @@ const PropertiesModal = ({
     } catch (error) {
       handleErrorResponse(error);
     }
-  }, [dashboardId]);
+  }, [addDangerToast, dashboardId]);
 
   const handleChangeTags = (tags: { label: string; value: number }[]) => {
     const parsedTags: TagType[] = ensureIsArray(tags).map(r => ({
@@ -610,6 +608,13 @@ const PropertiesModal = ({
     }));
     setTags(parsedTags);
   };
+
+  useEffect(() => {
+    // Initialize auto-sync charts setting from JSON metadata
+    setAutoSyncChartsEnabled(
+      getJsonMetadata()?.auto_sync_chart_owners === true,
+    );
+  }, [getJsonMetadata]);
 
   return (
     <Modal

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -261,17 +261,16 @@ const PropertiesModal = ({
     }, handleErrorResponse);
   }, [dashboardId, handleDashboardData, handleErrorResponse]);
 
-  const getJsonMetadata = useCallback(() => {
+  const getJsonMetadata = () => {
     try {
       const jsonMetadataObj = jsonMetadata?.length
         ? JSON.parse(jsonMetadata)
         : {};
-
       return jsonMetadataObj;
     } catch (_) {
       return {};
     }
-  }, [jsonMetadata]);
+  };
 
   const handleOnChangeOwners = (owners: { value: number; label: string }[]) => {
     const parsedOwners: Owners = ensureIsArray(owners).map(o => ({
@@ -620,10 +619,13 @@ const PropertiesModal = ({
 
   useEffect(() => {
     // Initialize auto-sync charts setting from JSON metadata
-    setAutoSyncChartsEnabled(
-      getJsonMetadata()?.auto_sync_chart_owners === true,
-    );
-  }, [getJsonMetadata]);
+    // Read and parse the jsonMetadata directly or we'll have to wrap getJsonMetadata in a useCallback
+    const jsonMetadataObj = jsonMetadata?.length
+      ? JSON.parse(jsonMetadata)
+      : {};
+
+    setAutoSyncChartsEnabled(jsonMetadataObj.auto_sync_chart_owners === true);
+  }, [jsonMetadata]);
 
   return (
     <Modal

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -606,13 +606,18 @@ const PropertiesModal = ({
   };
 
   useEffect(() => {
-    // Initialize auto-sync charts setting from JSON metadata
+    // Update auto-sync charts setting from JSON metadata
     // Read and parse the jsonMetadata directly or we'll have to wrap getJsonMetadata in a useCallback
-    const jsonMetadataObj = jsonMetadata?.length
-      ? JSON.parse(jsonMetadata)
-      : {};
+    let syncCharts = false;
 
-    const syncCharts = jsonMetadataObj.auto_sync_chart_owners === true;
+    try {
+      const jsonMetadataObj = jsonMetadata?.length
+        ? JSON.parse(jsonMetadata)
+        : {};
+      syncCharts = jsonMetadataObj.auto_sync_chart_owners === true;
+    } catch (_) {
+      syncCharts = false;
+    }
 
     setAutoSyncChartsEnabled(syncCharts);
 

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -117,6 +117,7 @@ const PropertiesModal = ({
   const saveLabel = onlyApply ? t('Apply') : t('Save');
   const [tags, setTags] = useState<TagType[]>([]);
   const [autoSyncChartsEnabled, setAutoSyncChartsEnabled] = useState(false);
+  const [hasFetchedCharts, setHasFetchedCharts] = useState(false);
   const [chartInfo, setChartInfo] = useState<Record<number, ChartInfo>>({});
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const canAccessRoles = userHasPermission(
@@ -131,9 +132,9 @@ const PropertiesModal = ({
       label: tag.name,
     }));
     return selectTags;
-  }, [tags.length]);
+  }, [tags]);
 
-  const handleErrorResponse = async (response: Response) => {
+  const handleErrorResponse = useCallback(async (response: Response) => {
     const { error, statusText, message } = await getClientErrorObject(response);
     let errorText = error || statusText || t('An error has occurred');
     if (typeof message === 'object' && 'json_metadata' in message) {
@@ -151,7 +152,7 @@ const PropertiesModal = ({
       content: errorText,
       okButtonProps: { danger: true, className: 'btn-danger' },
     });
-  };
+  }, []);
 
   const loadAccessOptions = useCallback(
     (accessType = 'owners', input = '', page: number, pageSize: number) => {
@@ -216,6 +217,27 @@ const PropertiesModal = ({
     [form],
   );
 
+  const fetchChartInfo = useCallback(() => {
+    SupersetClient.get({
+      endpoint: `/api/v1/dashboard/${dashboardId}/charts`,
+    })
+      .then(response => {
+        setHasFetchedCharts(true);
+
+        const charts = response.json.result;
+        const chartInfoMap: Record<number, ChartInfo> = {};
+        charts.forEach((chart: any) => {
+          chartInfoMap[chart.id] = {
+            id: chart.id,
+            name: chart.slice_name,
+            ownerIds: (chart.owners ?? []).map((owner: any) => owner.id),
+          };
+        });
+        setChartInfo(chartInfoMap);
+      })
+      .catch(handleErrorResponse);
+  }, [dashboardId, handleErrorResponse]);
+
   const fetchDashboardDetails = useCallback(() => {
     setIsLoading(true);
     // We fetch the dashboard details because not all code
@@ -236,26 +258,20 @@ const PropertiesModal = ({
       });
 
       setIsLoading(false);
-
-      //  After fetching initial dashboard data
-      setAutoSyncChartsEnabled(
-        jsonMetadataObj?.auto_sync_chart_owners ?? false,
-      );
-
-      fetchChartInfo();
     }, handleErrorResponse);
-  }, [dashboardId, handleDashboardData]);
+  }, [dashboardId, handleDashboardData, handleErrorResponse]);
 
-  const getJsonMetadata = () => {
+  const getJsonMetadata = useCallback(() => {
     try {
       const jsonMetadataObj = jsonMetadata?.length
         ? JSON.parse(jsonMetadata)
         : {};
+
       return jsonMetadataObj;
     } catch (_) {
       return {};
     }
-  };
+  }, [jsonMetadata]);
 
   const handleOnChangeOwners = (owners: { value: number; label: string }[]) => {
     const parsedOwners: Owners = ensureIsArray(owners).map(o => ({
@@ -537,25 +553,6 @@ const PropertiesModal = ({
     />
   );
 
-  const fetchChartInfo = useCallback(() => {
-    SupersetClient.get({
-      endpoint: `/api/v1/dashboard/${dashboardId}/charts`,
-    })
-      .then(response => {
-        const charts = response.json.result;
-        const chartInfoMap: Record<number, ChartInfo> = {};
-        charts.forEach((chart: any) => {
-          chartInfoMap[chart.id] = {
-            id: chart.id,
-            name: chart.slice_name,
-            ownerIds: chart.owners.map((owner: any) => owner.id),
-          };
-        });
-        setChartInfo(chartInfoMap);
-      })
-      .catch(handleErrorResponse);
-  }, [dashboardId, handleErrorResponse]);
-
   useEffect(() => {
     if (show) {
       if (!currentDashboardInfo) {
@@ -563,10 +560,22 @@ const PropertiesModal = ({
       } else {
         handleDashboardData(currentDashboardInfo);
       }
+
+      // Fetch chart info when the modal is shown
+      if (!hasFetchedCharts) {
+        fetchChartInfo();
+      }
     }
 
     JsonEditor.preload();
-  }, [currentDashboardInfo, fetchDashboardDetails, handleDashboardData, show]);
+  }, [
+    currentDashboardInfo,
+    fetchChartInfo,
+    fetchDashboardDetails,
+    handleDashboardData,
+    hasFetchedCharts,
+    show,
+  ]);
 
   useEffect(() => {
     // the title can be changed inline in the dashboard, this catches it
@@ -599,7 +608,7 @@ const PropertiesModal = ({
     } catch (error) {
       handleErrorResponse(error);
     }
-  }, [addDangerToast, dashboardId]);
+  }, [addDangerToast, dashboardId, handleErrorResponse]);
 
   const handleChangeTags = (tags: { label: string; value: number }[]) => {
     const parsedTags: TagType[] = ensureIsArray(tags).map(r => ({
@@ -618,6 +627,7 @@ const PropertiesModal = ({
 
   return (
     <Modal
+      aria-label={t('Dashboard properties')}
       show={show}
       onHide={onHide}
       title={t('Dashboard properties')}

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -625,7 +625,6 @@ const PropertiesModal = ({
 
   return (
     <Modal
-      aria-label={t('Dashboard properties')}
       show={show}
       onHide={onHide}
       title={t('Dashboard properties')}

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -87,6 +87,11 @@ type DashboardInfo = {
   certificationDetails: string;
   isManagedExternally: boolean;
 };
+type ChartInfo = {
+  id: number;
+  name: string;
+  ownerIds: number[];
+};
 
 const PropertiesModal = ({
   addSuccessToast,
@@ -111,6 +116,8 @@ const PropertiesModal = ({
   const [roles, setRoles] = useState<Roles>([]);
   const saveLabel = onlyApply ? t('Apply') : t('Save');
   const [tags, setTags] = useState<TagType[]>([]);
+  const [autoSyncChartsEnabled, setAutoSyncChartsEnabled] = useState(false);
+  const [chartInfo, setChartInfo] = useState<Record<string, any>>({});
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const canAccessRoles = userHasPermission(
     user,
@@ -229,6 +236,13 @@ const PropertiesModal = ({
       });
 
       setIsLoading(false);
+
+      //  After fetching initial dashboard data
+      setAutoSyncChartsEnabled(
+        jsonMetadataObj?.auto_sync_chart_owners ?? false,
+      );
+
+      fetchChartInfo();
     }, handleErrorResponse);
   }, [dashboardId, handleDashboardData]);
 
@@ -509,32 +523,47 @@ const PropertiesModal = ({
     );
   };
 
-  const getSyncChartsCheckbox = () => {
-    const jsonMetadataObj = getJsonMetadata();
-    const hasSyncChartsEnabled =
-      jsonMetadataObj?.auto_sync_chart_owners || false;
+  const getAutoSyncChartsCheckbox = () => (
+    <>
+      <Checkbox
+        checked={autoSyncChartsEnabled}
+        onChange={val => {
+          const nextVal = val ?? false;
+          const jsonMetadataObj = getJsonMetadata();
+          jsonMetadataObj.auto_sync_chart_owners = nextVal;
 
-    return (
-      <>
-        <Checkbox
-          checked={hasSyncChartsEnabled}
-          onChange={e => {
-            const jsonMetadataObj = getJsonMetadata();
-            jsonMetadataObj.auto_sync_chart_owners = e;
-            setJsonMetadata(jsonStringify(jsonMetadataObj));
-          }}
-          style={{ marginRight: '8px' }}
-        />
-        <span>{t('Sync chart owners')}</span>
+          setAutoSyncChartsEnabled(nextVal);
+          setJsonMetadata(jsonStringify(jsonMetadataObj));
+        }}
+        style={{ marginRight: '8px' }}
+      />
+      <span>{t('Sync chart owners')}</span>
+      <p className="help-block">
+        {t(
+          'Update owners of all charts in this dashboard to include dashboard owners.',
+        )}
+      </p>
+    </>
+  );
 
-        <p className="help-block">
-          {t(
-            'Update owners of all charts in this dashboard to include dashboard owners.',
-          )}
-        </p>
-      </>
-    );
-  };
+  const fetchChartInfo = useCallback(() => {
+    SupersetClient.get({
+      endpoint: `/api/v1/dashboard/${dashboardId}/charts`,
+    })
+      .then(response => {
+        const charts = response.json.result;
+        const chartInfoMap: Record<string, ChartInfo> = {};
+        charts.forEach((chart: any) => {
+          chartInfoMap[chart.id] = {
+            id: chart.id,
+            name: chart.slice_name,
+            ownerIds: chart.owners.map((owner: any) => owner.id),
+          };
+        });
+        setChartInfo(chartInfoMap);
+      })
+      .catch(handleErrorResponse);
+  }, [dashboardId, handleErrorResponse]);
 
   useEffect(() => {
     if (show) {
@@ -662,7 +691,8 @@ const PropertiesModal = ({
           {isFeatureEnabled(FeatureFlag.DashboardRbac) && canAccessRoles
             ? getRowsWithRoles()
             : getRowsWithoutRoles()}
-          {getSyncChartsCheckbox()}
+          <p>Auto - sync: {autoSyncChartsEnabled ? 'True' : 'False'}</p>
+          {getAutoSyncChartsCheckbox()}
         </>
         <Row>
           <Col xs={24} md={24}>

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -52,7 +52,7 @@ import {
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
 import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
-import SyncChartOwnersControl from './SyncChartOwnersControl';
+import SyncChartOwnersControl from 'src/dashboard/components/PropertiesModal/SyncChartOwnersControl';
 
 const StyledFormItem = styled(FormItem)`
   margin-bottom: 0;

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -52,7 +52,7 @@ import {
 import { applyColors, getColorNamespace } from 'src/utils/colorScheme';
 import { getOwnerDisplayName } from 'src/utils/getOwnerName';
 import Owner from 'src/types/Owner';
-import Checkbox from 'src/components/Checkbox';
+import SyncChartOwnersControl from './SyncChartOwnersControl';
 
 const StyledFormItem = styled(FormItem)`
   margin-bottom: 0;
@@ -87,7 +87,7 @@ type DashboardInfo = {
   certificationDetails: string;
   isManagedExternally: boolean;
 };
-type ChartInfo = {
+export type ChartInfo = {
   id: number;
   name: string;
   ownerIds: number[];
@@ -117,7 +117,7 @@ const PropertiesModal = ({
   const saveLabel = onlyApply ? t('Apply') : t('Save');
   const [tags, setTags] = useState<TagType[]>([]);
   const [autoSyncChartsEnabled, setAutoSyncChartsEnabled] = useState(false);
-  const [chartInfo, setChartInfo] = useState<Record<string, any>>({});
+  const [chartInfo, setChartInfo] = useState<Record<number, ChartInfo>>({});
   const categoricalSchemeRegistry = getCategoricalSchemeRegistry();
   const canAccessRoles = userHasPermission(
     user,
@@ -523,27 +523,20 @@ const PropertiesModal = ({
     );
   };
 
-  const getAutoSyncChartsCheckbox = () => (
-    <>
-      <Checkbox
-        checked={autoSyncChartsEnabled}
-        onChange={val => {
-          const nextVal = val ?? false;
-          const jsonMetadataObj = getJsonMetadata();
-          jsonMetadataObj.auto_sync_chart_owners = nextVal;
+  const getAutoSyncChartsControl = () => (
+    <SyncChartOwnersControl
+      autoSyncChartsEnabled={autoSyncChartsEnabled}
+      onChange={(val: boolean): void => {
+        const nextVal = val ?? false;
+        const jsonMetadataObj = getJsonMetadata();
+        jsonMetadataObj.auto_sync_chart_owners = nextVal;
 
-          setAutoSyncChartsEnabled(nextVal);
-          setJsonMetadata(jsonStringify(jsonMetadataObj));
-        }}
-        style={{ marginRight: '8px' }}
-      />
-      <span>{t('Sync chart owners')}</span>
-      <p className="help-block">
-        {t(
-          'Update owners of all charts in this dashboard to include dashboard owners.',
-        )}
-      </p>
-    </>
+        setAutoSyncChartsEnabled(nextVal);
+        setJsonMetadata(jsonStringify(jsonMetadataObj));
+      }}
+      dashboardOwnerIds={owners.map(owner => owner.id)}
+      chartInfoMap={chartInfo}
+    />
   );
 
   const fetchChartInfo = useCallback(() => {
@@ -552,7 +545,7 @@ const PropertiesModal = ({
     })
       .then(response => {
         const charts = response.json.result;
-        const chartInfoMap: Record<string, ChartInfo> = {};
+        const chartInfoMap: Record<number, ChartInfo> = {};
         charts.forEach((chart: any) => {
           chartInfoMap[chart.id] = {
             id: chart.id,
@@ -691,8 +684,7 @@ const PropertiesModal = ({
           {isFeatureEnabled(FeatureFlag.DashboardRbac) && canAccessRoles
             ? getRowsWithRoles()
             : getRowsWithoutRoles()}
-          <p>Auto - sync: {autoSyncChartsEnabled ? 'True' : 'False'}</p>
-          {getAutoSyncChartsCheckbox()}
+          {getAutoSyncChartsControl()}
         </>
         <Row>
           <Col xs={24} md={24}>

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -218,12 +218,12 @@ const PropertiesModal = ({
   );
 
   const fetchChartInfo = useCallback(() => {
+    setHasFetchedCharts(true);
+
     SupersetClient.get({
       endpoint: `/api/v1/dashboard/${dashboardId}/charts`,
     })
       .then(response => {
-        setHasFetchedCharts(true);
-
         const charts = response.json.result;
         const chartInfoMap: Record<number, ChartInfo> = {};
         charts.forEach((chart: any) => {
@@ -559,22 +559,10 @@ const PropertiesModal = ({
       } else {
         handleDashboardData(currentDashboardInfo);
       }
-
-      // Fetch chart info when the modal is shown
-      if (!hasFetchedCharts) {
-        fetchChartInfo();
-      }
     }
 
     JsonEditor.preload();
-  }, [
-    currentDashboardInfo,
-    fetchChartInfo,
-    fetchDashboardDetails,
-    handleDashboardData,
-    hasFetchedCharts,
-    show,
-  ]);
+  }, [currentDashboardInfo, fetchDashboardDetails, handleDashboardData, show]);
 
   useEffect(() => {
     // the title can be changed inline in the dashboard, this catches it
@@ -624,8 +612,16 @@ const PropertiesModal = ({
       ? JSON.parse(jsonMetadata)
       : {};
 
-    setAutoSyncChartsEnabled(jsonMetadataObj.auto_sync_chart_owners === true);
-  }, [jsonMetadata]);
+    const syncCharts = jsonMetadataObj.auto_sync_chart_owners === true;
+
+    setAutoSyncChartsEnabled(syncCharts);
+
+    // Fetch chart info when sync is enabled for the first time
+    if (syncCharts && !hasFetchedCharts) {
+      setHasFetchedCharts(true);
+      fetchChartInfo();
+    }
+  }, [fetchChartInfo, hasFetchedCharts, jsonMetadata]);
 
   return (
     <Modal

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -623,7 +623,6 @@ const PropertiesModal = ({
 
     // Fetch chart info when sync is enabled for the first time
     if (syncCharts && !hasFetchedCharts) {
-      setHasFetchedCharts(true);
       fetchChartInfo();
     }
   }, [fetchChartInfo, hasFetchedCharts, jsonMetadata]);

--- a/superset/charts/schemas.py
+++ b/superset/charts/schemas.py
@@ -26,6 +26,7 @@ from marshmallow.validate import Length, Range
 
 from superset import app
 from superset.common.chart_data import ChartDataResultFormat, ChartDataResultType
+from superset.dashboards.schemas import UserSchema
 from superset.db_engine_specs.base import builtin_time_grains
 from superset.utils import pandas_postprocessing, schema as utils
 from superset.utils.core import (
@@ -162,6 +163,7 @@ class ChartEntityResponseSchema(Schema):
     certification_details = fields.String(
         metadata={"description": certification_details_description}
     )
+    owners = fields.List(fields.Nested(UserSchema), metadata={"description": owners_description})
 
 
 class ChartPostSchema(Schema):

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -483,7 +483,9 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         A chart will have its own owners updated if the owners of the dashboard
         and chart have mutual owners.
         """
-        print("Syncing dashboard chart owners...:" + self.auto_sync_chart_owners)
+        print(
+            "Syncing dashboard chart owners...:" + str(self.auto_sync_chart_owners)
+        )
         if not self.auto_sync_chart_owners:
             return
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -483,21 +483,27 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         A chart will have its own owners updated if the owners of the dashboard
         and chart have mutual owners.
         """
+        print("Syncing dashboard chart owners...:" + self.auto_sync_chart_owners)
         if not self.auto_sync_chart_owners:
             return
 
         dashboard_owner_ids = {owner.id for owner in self.owners}
+        print(f"Dashboard owner IDs: {dashboard_owner_ids}")
 
         for slice in self.slices:
             slice_owner_ids = {owner.id for owner in slice.owners}
+            print(f"Slice {slice.id} owner IDs: {slice_owner_ids}")
 
             if not bool(dashboard_owner_ids & slice_owner_ids):
+                print(f"No mutual owners for slice {slice.id}, skipping...")
                 continue
 
             if dashboard_owner_ids.issubset(slice_owner_ids):
+                print(f"Slice {slice.id} already has all dashboard owners, skipping...")
                 continue
 
             slice.owners = list(set(slice.owners) | set(self.owners))
+            print(f"Adding dashboard owners to slice {slice.id}...")
 
         db.session.commit()
 

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -483,29 +483,21 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         A chart will have its own owners updated if the owners of the dashboard
         and chart have mutual owners.
         """
-        print(
-            "Syncing dashboard chart owners...:" + str(self.auto_sync_chart_owners)
-        )
         if not self.auto_sync_chart_owners:
             return
 
         dashboard_owner_ids = {owner.id for owner in self.owners}
-        print(f"Dashboard owner IDs: {dashboard_owner_ids}")
 
         for slice in self.slices:
             slice_owner_ids = {owner.id for owner in slice.owners}
-            print(f"Slice {slice.id} owner IDs: {slice_owner_ids}")
 
             if not bool(dashboard_owner_ids & slice_owner_ids):
-                print(f"No mutual owners for slice {slice.id}, skipping...")
                 continue
 
             if dashboard_owner_ids.issubset(slice_owner_ids):
-                print(f"Slice {slice.id} already has all dashboard owners, skipping...")
                 continue
 
             slice.owners = list(set(slice.owners) | set(self.owners))
-            print(f"Adding dashboard owners to slice {slice.id}...")
 
         db.session.commit()
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3030,16 +3030,18 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         )
         admin = self.get_user("admin")
 
+        trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
+
         # Insert dashboard with owners
         dashboard = self.insert_dashboard(
             "title1",
             "slug1",
             [user_alpha1.id, admin.id],
+            slices=[trends]
         )
 
         boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
         girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
-        trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
 
         boys.owners = [user_alpha1]
         girls.owners = [user_alpha2]

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3053,7 +3053,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
                     "auto_sync_chart_owners": True
                 }
             ),
-            "slices": json.dumps([boys, girls, trends])
+            "slices": [boys, girls, trends]
         }
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3053,7 +3053,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
                     "auto_sync_chart_owners": True
                 }
             ),
-            "slices": [boys, girls, trends]
+            "slices": json.dumps([boys, girls, trends])
         }
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -18,6 +18,7 @@
 """Unit tests for Superset"""
 
 from io import BytesIO
+import logging
 from time import sleep
 from unittest.mock import ANY, patch
 from zipfile import is_zipfile, ZipFile
@@ -71,6 +72,7 @@ from tests.integration_tests.fixtures.world_bank_dashboard import (
 
 DASHBOARDS_FIXTURE_COUNT = 10
 
+logger = logging.getLogger(__name__)
 
 class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
     resource_name = "dashboard"
@@ -3059,6 +3061,12 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.put(uri, json=dashboard_data)
+
+        logger.warning(f"Status code: {rv.status_code}")
+        logger.warning(f"Response data: {rv.data.decode('utf-8')}")
+        print(f"Status code: {rv.status_code}")
+        print(f"Response data: {rv.data.decode('utf-8')}")
+
         self.assertEqual(rv.status_code, 200)
 
         # Check that chart owners were updated

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3029,6 +3029,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         )
         admin = self.get_user("admin")
 
+        boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
+        girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
         trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
 
         # Insert dashboard with owners
@@ -3036,15 +3038,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             "title1",
             "slug1",
             [user_alpha1.id, admin.id],
-            json_metadata=json.dumps(
-                {
-                    "auto_sync_chart_owners": True
-                }
-            ),
+            slices=[boys, girls, trends]
         )
-
-        boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
-        girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
 
         boys.owners = [user_alpha1]
         girls.owners = [user_alpha2]
@@ -3053,24 +3048,13 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         db.session.commit()
 
         dashboard_data = {
-            "position_json": json.dumps({
-                f"CHART-{boys.id}": {
-                    "type": "CHART",
-                    "meta": {"chartId": boys.id},
-                    "id": f"CHART-{boys.id}"
-                },
-                f"CHART-{girls.id}": {
-                    "type": "CHART",
-                    "meta": {"chartId": girls.id},
-                    "id": f"CHART-{girls.id}"
-                },
-                f"CHART-{trends.id}": {
-                    "type": "CHART",
-                    "meta": {"chartId": trends.id},
-                    "id": f"CHART-{trends.id}"
+            "json_metadata": json.dumps(
+                {
+                    "auto_sync_chart_owners": True
                 }
-            })
+            ),
         }
+
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.put(uri, json=dashboard_data)

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -18,7 +18,6 @@
 """Unit tests for Superset"""
 
 from io import BytesIO
-import logging
 from time import sleep
 from unittest.mock import ANY, patch
 from zipfile import is_zipfile, ZipFile
@@ -71,8 +70,6 @@ from tests.integration_tests.fixtures.world_bank_dashboard import (
 )
 
 DASHBOARDS_FIXTURE_COUNT = 10
-
-logger = logging.getLogger(__name__)
 
 class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCase):
     resource_name = "dashboard"
@@ -3078,8 +3075,6 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.put(uri, json=dashboard_data)
 
-        logger.warning(f"Status code: {rv.status_code}")
-        logger.warning(f"Response data: {rv.data.decode('utf-8')}")
         print(f"Status code: {rv.status_code}")
         print(f"Response data: {rv.data.decode('utf-8')}")
 

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3056,7 +3056,23 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         db.session.commit()
 
         dashboard_data = {
-            "slices": [boys.id, girls.id, trends.id]
+            "position_json": json.dumps({
+                f"CHART-{boys.id}": {
+                    "type": "CHART",
+                    "meta": {"chartId": boys.id},
+                    "id": f"CHART-{boys.id}"
+                },
+                f"CHART-{girls.id}": {
+                    "type": "CHART",
+                    "meta": {"chartId": girls.id},
+                    "id": f"CHART-{girls.id}"
+                },
+                f"CHART-{trends.id}": {
+                    "type": "CHART",
+                    "meta": {"chartId": trends.id},
+                    "id": f"CHART-{trends.id}"
+                }
+            })
         }
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3053,7 +3053,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
                     "auto_sync_chart_owners": True
                 }
             ),
-            "slices": [boys, girls, trends]
+            "slices": [boys.id, girls.id, trends.id]
         }
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3058,13 +3058,8 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         self.login(ADMIN_USERNAME)
         uri = f"api/v1/dashboard/{dashboard.id}"
         rv = self.client.put(uri, json=dashboard_data)
-
-        print(f"Status code: {rv.status_code}")
-        print(f"Response data: {rv.data.decode('utf-8')}")
-
         self.assertEqual(rv.status_code, 200)
 
-        # Check that chart owners were updated
         boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
         girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
         trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
@@ -3091,4 +3086,5 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         # Rollback changes
         db.session.delete(dashboard)
         db.session.delete(user_alpha1)
+        db.session.delete(user_alpha2)
         db.session.commit()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -390,6 +390,7 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             "description_markeddown",
             "form_data",
             "id",
+            "owners",
             "slice_name",
             "slice_url",
         }

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3008,3 +3008,83 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
 
         response = self._cache_screenshot(dashboard.id)
         assert response.status_code == 404
+
+    @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")
+    def test_dashboard_chart_owners_sync(self):
+        """
+        Dashboard API: Test chart owners get updated when added to a dashboard with auto sync enabled
+        """
+        user_alpha1 = self.create_user(
+            "alpha1",
+            "password",
+            "Alpha",
+            email="alpha1@superset.org",
+            first_name="alpha1",
+        )
+        user_alpha2 = self.create_user(
+            "alpha2",
+            "password",
+            "Alpha",
+            email="alpha2@superset.org",
+            first_name="alpha2",
+        )
+        admin = self.get_user("admin")
+
+        # Insert dashboard with owners
+        dashboard = self.insert_dashboard(
+            "title1",
+            "slug1",
+            [user_alpha1.id, admin.id],
+        )
+
+        boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
+        girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
+        trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
+
+        boys.owners = [user_alpha1]
+        girls.owners = [user_alpha2]
+        trends.owners = []
+
+        db.session.commit()
+
+        dashboard_data = {
+            "json_metadata": json.dumps(
+                {
+                    "auto_sync_chart_owners": True
+                }
+            ),
+            "slices": [boys, girls, trends]
+        }
+        self.login(ADMIN_USERNAME)
+        uri = f"api/v1/dashboard/{dashboard.id}"
+        rv = self.client.put(uri, json=dashboard_data)
+        self.assertEqual(rv.status_code, 200)
+
+        # Check that chart owners were updated
+        boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
+        girls = db.session.query(Slice).filter_by(slice_name="Girls").one()
+        trends = db.session.query(Slice).filter_by(slice_name="Trends").one()
+
+        # Check that chart owners were updated to match dashboard owners
+        self.assertIn(user_alpha1, boys.owners)
+        self.assertIn(admin, boys.owners)
+        # user_alpha2 is not an owner of the dashboard
+        self.assertNotIn(user_alpha2, boys.owners)
+
+        self.assertIn(user_alpha2, girls.owners)
+        # owners of Girls does not have mutual owners of the dashboard
+        self.assertNotIn(user_alpha1, girls.owners)
+        self.assertNotIn(admin, girls.owners)
+
+        # Trends has no owners so there should be no updates
+        self.assertEqual(trends.owners, [])
+
+        # Revert owners on slice
+        for slice in [boys, girls, trends]:
+            slice.owners = []
+            db.session.commit()
+
+        # Rollback changes
+        db.session.delete(dashboard)
+        db.session.delete(user_alpha1)
+        db.session.commit()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -3037,7 +3037,11 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
             "title1",
             "slug1",
             [user_alpha1.id, admin.id],
-            slices=[trends]
+            json_metadata=json.dumps(
+                {
+                    "auto_sync_chart_owners": True
+                }
+            ),
         )
 
         boys = db.session.query(Slice).filter_by(slice_name="Boys").one()
@@ -3050,11 +3054,6 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         db.session.commit()
 
         dashboard_data = {
-            "json_metadata": json.dumps(
-                {
-                    "auto_sync_chart_owners": True
-                }
-            ),
             "slices": [boys.id, girls.id, trends.id]
         }
         self.login(ADMIN_USERNAME)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates the dashboard properties modal with the following:
- Adds a checkbox to add dashboard owners to all charts with permissions
- Adds a warning icon with tooltip to alert missing permissions when the checkbox is checked
- Updating the checkbox will update the json metadata, and vice versa
- There is an extra API call to fetch charts included in the dashboard. This gets called once the checkbox is checked for the first time, or if it's checked upon modal initialization

**Note:** Added some of the missing dependencies in the `useEffect` or `useCallbacks` in the PropertiesModal

### VIDEOS
<!--- Skip this if not applicable -->
#### Charts Before
<img width="1251" height="613" alt="charts" src="https://github.com/user-attachments/assets/882924d8-5261-429e-96b1-eae661e3d738" />

#### Sync checkbox

https://github.com/user-attachments/assets/2b1e185a-c6d0-4b18-9f91-061ca249a7f5

#### Syncing operation

https://github.com/user-attachments/assets/09288ff2-7281-45ca-bd93-3282265a332b


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Added tests for new `SyncChartOwnersControl` component
- Added new tests in the `PropertiesModal.test.tsx` to test that the checkbox and API call was being handled as expected
- Added an integration test to check that chart owners were being updated via a put request


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
