### PR TITLE
feat: anomaly detection

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
@@ -1,0 +1,28 @@
+import {
+  PostProcessingAnomalyDetection,
+  getXAxisLabel,
+} from '@superset-ui/core';
+import { PostProcessingFactory } from './types';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const anomalyDetectionOperator: PostProcessingFactory<
+  PostProcessingAnomalyDetection
+> = (formData, queryObject) => {
+  const xAxisLabel = getXAxisLabel(formData);
+  if (formData.anomalyDetectionEnabled && xAxisLabel) {
+    return {
+      operation: 'anomaly_detection',
+      options: {
+        contamination_rate: parseFloat(
+          formData.anomalyDetectionContaminationRate,
+        ),
+        detrend: formData.anomalyDetectionDetrend,
+        yearly_seasonality: formData.anomalyDetectionYearlySeasonality,
+        monthly_seasonality: formData.anomalyDetectionMonthlySeasonality,
+        weekly_seasonality: formData.anomalyDetectionWeeklySeasonality,
+        index: xAxisLabel,
+      },
+    };
+  }
+  return undefined;
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/index.ts
@@ -27,6 +27,7 @@ export { resampleOperator } from './resampleOperator';
 export { renameOperator } from './renameOperator';
 export { contributionOperator } from './contributionOperator';
 export { prophetOperator } from './prophetOperator';
+export { anomalyDetectionOperator } from './anomalyDetectionOperator';
 export { boxplotOperator } from './boxplotOperator';
 export { flattenOperator } from './flattenOperator';
 export { rankOperator } from './rankOperator';

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
@@ -50,7 +50,7 @@ export const anomalyDetectionControls: ControlPanelSectionConfig = {
         name: 'anomalyDetectionDetrend',
         config: {
           type: 'CheckboxControl',
-          label: t('Remove the trend from the data first'),
+          label: t('Remove trend from data first'),
           renderTrigger: false,
           default: ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionDetrend,
           description: t(

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
@@ -1,0 +1,108 @@
+import { legacyValidateNumber, t } from '@superset-ui/core';
+import { ControlPanelSectionConfig } from '../types';
+import { displayTimeRelatedControls } from '../utils';
+
+export const ANOMALY_DETECTION_DEFAULT_DATA = {
+  anomalyDetectionEnabled: false,
+  anomalyDetectionContaminationRate: 0.05,
+  anomalyDetectionDetrend: true,
+  anomalyDetectionYearlySeasonality: true,
+  anomalyDetectionMonthlySeasonality: true,
+  anomalyDetectionWeeklySeasonality: false,
+};
+
+export const anomalyDetectionControls: ControlPanelSectionConfig = {
+  label: t('Warden Anomaly Detection'),
+  expanded: false,
+  visibility: displayTimeRelatedControls,
+  controlSetRows: [
+    [
+      {
+        name: 'anomalyDetectionEnabled',
+        config: {
+          type: 'CheckboxControl',
+          label: t('Enable anomaly detection'),
+          renderTrigger: false,
+          default: ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionEnabled,
+          description: t('Enable anomaly detection for the data.'),
+        },
+      },
+    ],
+    [
+      {
+        name: 'anomalyDetectionContaminationRate',
+        config: {
+          type: 'TextControl',
+          label: t(
+            'What proportion of data points do you think could be anomalies?',
+          ),
+          validators: [legacyValidateNumber],
+          default:
+            ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionContaminationRate,
+          description: t(
+            'Usually somewhere between 0.01 to 0.05 (i.e. 1% to 5% of the data is anomalous).',
+          ),
+        },
+      },
+    ],
+    [
+      {
+        name: 'anomalyDetectionDetrend',
+        config: {
+          type: 'CheckboxControl',
+          label: t('Remove the trend from the data first'),
+          renderTrigger: false,
+          default: ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionDetrend,
+          description: t(
+            'Select this if your data is generally trending up or down, and you would like the anomaly detection model to NOT consider the trend when detecting anomalies. (This is especially useful if you want to detect local dips or spikes.)',
+          ),
+        },
+      },
+    ],
+    [
+      {
+        name: 'anomalyDetectionYearlySeasonality',
+        config: {
+          type: 'CheckboxControl',
+          label: t('Yearly seasonality'),
+          renderTrigger: false,
+          default:
+            ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionYearlySeasonality,
+          description: t(
+            'Select this if the data behaves similarly the same time each year, and you would like the anomaly detection model to take that into account.',
+          ),
+        },
+      },
+    ],
+    [
+      {
+        name: 'anomalyDetectionMonthlySeasonality',
+        config: {
+          type: 'CheckboxControl',
+          label: t('Monthly seasonality'),
+          renderTrigger: false,
+          default:
+            ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionMonthlySeasonality,
+          description: t(
+            'Select this if the data behaves similarly the same time each month, and you would like the anomaly detection model to take that into account.',
+          ),
+        },
+      },
+    ],
+    [
+      {
+        name: 'anomalyDetectionWeeklySeasonality',
+        config: {
+          type: 'CheckboxControl',
+          label: t('Weekly seasonality'),
+          renderTrigger: false,
+          default:
+            ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionWeeklySeasonality,
+          description: t(
+            'Select this if the data behaves similarly the same time each week, and you would like the anomaly detection model to take that into account.',
+          ),
+        },
+      },
+    ],
+  ],
+};

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/anomalyDetection.tsx
@@ -13,6 +13,11 @@ export const ANOMALY_DETECTION_DEFAULT_DATA = {
 
 export const anomalyDetectionControls: ControlPanelSectionConfig = {
   label: t('Warden Anomaly Detection'),
+  description: t(
+    'Detects time-series anomalies and assigns each a 0-1 score ' +
+      "indicating confidence in it being a true anomaly (1 = very confident). " +
+      'Excels at detecting local spikes and dips.',
+  ),
   expanded: false,
   visibility: displayTimeRelatedControls,
   controlSetRows: [

--- a/superset-frontend/packages/superset-ui-chart-controls/src/sections/index.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/sections/index.ts
@@ -21,6 +21,7 @@ export * from './sections';
 export * from './advancedAnalytics';
 export * from './annotationsAndLayers';
 export * from './forecastInterval';
+export * from './anomalyDetection';
 export * from './chartTitle';
 export * from './echartsTimeSeriesQuery';
 export * from './timeComparison';

--- a/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/PostProcessing.ts
@@ -134,6 +134,20 @@ export type PostProcessingProphet =
   | _PostProcessingProphet
   | DefaultPostProcessing;
 
+interface _PostProcessingAnomalyDetection {
+  operation: 'anomaly_detection';
+  options: {
+    contamination_rate: number;
+    detrend?: boolean;
+    yearly_seasonality?: boolean;
+    monthly_seasonality?: boolean;
+    weekly_seasonality?: boolean;
+  };
+}
+export type PostProcessingAnomalyDetection =
+  | _PostProcessingAnomalyDetection
+  | DefaultPostProcessing;
+
 interface _PostProcessingDiff {
   operation: 'diff';
   options: {
@@ -257,6 +271,7 @@ export type PostProcessingRule =
   | PostProcessingContribution
   | PostProcessingPivot
   | PostProcessingProphet
+  | PostProcessingAnomalyDetection
   | PostProcessingDiff
   | PostProcessingRolling
   | PostProcessingCum
@@ -296,6 +311,12 @@ export function isPostProcessingProphet(
   rule?: PostProcessingRule,
 ): rule is PostProcessingProphet {
   return rule?.operation === 'prophet';
+}
+
+export function isPostProcessingAnomalyDetection(
+  rule?: PostProcessingRule,
+): rule is PostProcessingAnomalyDetection {
+  return rule?.operation === 'anomaly_detection';
 }
 
 export function isPostProcessingDiff(

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Area/controlPanel.tsx
@@ -62,6 +62,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Bar/controlPanel.tsx
@@ -258,6 +258,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     {
       label: t('Chart Orientation'),
       expanded: true,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Line/controlPanel.tsx
@@ -63,6 +63,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/Scatter/controlPanel.tsx
@@ -58,6 +58,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Regular/SmoothLine/controlPanel.tsx
@@ -58,6 +58,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/Step/controlPanel.tsx
@@ -58,6 +58,7 @@ const config: ControlPanelConfig = {
     sections.advancedAnalyticsControls,
     sections.annotationsAndLayersControls,
     sections.forecastIntervalControls,
+    sections.anomalyDetectionControls,
     sections.titleControls,
     {
       label: t('Chart Options'),

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/buildQuery.ts
@@ -38,6 +38,7 @@ import {
   sortOperator,
   timeComparePivotOperator,
   timeCompareOperator,
+  anomalyDetectionOperator,
 } from '@superset-ui/chart-controls';
 
 export default function buildQuery(formData: QueryFormData) {
@@ -107,6 +108,7 @@ export default function buildQuery(formData: QueryFormData) {
           flattenOperator(formData, baseQueryObject),
           // todo: move prophet before flatten
           prophetOperator(formData, baseQueryObject),
+          anomalyDetectionOperator(formData, baseQueryObject),
         ],
       },
     ];

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/constants.ts
@@ -61,6 +61,18 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
     sections.FORECAST_DEFAULT_DATA.forecastSeasonalityWeekly,
   forecastSeasonalityYearly:
     sections.FORECAST_DEFAULT_DATA.forecastSeasonalityYearly,
+  anomalyDetectionEnabled:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionEnabled,
+  anomalyDetectionContaminationRate:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionContaminationRate,
+  anomalyDetectionDetrend:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionDetrend,
+  anomalyDetectionYearlySeasonality:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionYearlySeasonality,
+  anomalyDetectionMonthlySeasonality:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionMonthlySeasonality,
+  anomalyDetectionWeeklySeasonality:
+    sections.ANOMALY_DETECTION_DEFAULT_DATA.anomalyDetectionWeeklySeasonality,
   logAxis: false,
   markerEnabled: false,
   markerSize: 6,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -57,7 +57,13 @@ import {
   TimeseriesChartTransformedProps,
 } from './types';
 import { DEFAULT_FORM_DATA } from './constants';
-import { ForecastSeriesEnum, ForecastValue, Refs } from '../types';
+import {
+  ForecastSeriesEnum,
+  ForecastValue,
+  Refs,
+  RawSeriesEntry,
+  AnomalyLookup,
+} from '../types';
 import { parseAxisBound } from '../utils/controls';
 import {
   calculateLowerLogTick,
@@ -82,6 +88,11 @@ import {
   formatForecastTooltipSeries,
   rebaseForecastDatum,
 } from '../utils/forecast';
+import {
+  createAnomalyLookup,
+  processAnomaliesForChart,
+  isSeriesAboutAnomaly,
+} from '../utils/anomalyDetection';
 import { convertInteger } from '../utils/convertInteger';
 import { defaultGrid, defaultYAxis } from '../defaults';
 import {
@@ -284,7 +295,12 @@ export default function transformProps(
 
   const offsetLineWidths = {};
 
-  rawSeries.forEach(entry => {
+  const anomalyLookup: AnomalyLookup = createAnomalyLookup(
+    rawSeries as RawSeriesEntry[],
+    inverted,
+  );
+
+  (rawSeries as RawSeriesEntry[]).forEach(entry => {
     const derivedSeries = isDerivedSeries(entry, chartProps.rawFormData);
     const lineStyle: LineStyleOption = {};
     if (derivedSeries) {
@@ -302,6 +318,10 @@ export default function transformProps(
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
     const colorScaleKey = getOriginalSeries(seriesName, array);
+
+    if (isSeriesAboutAnomaly(seriesName)) {
+      return;
+    }
 
     const transformedSeries = transformSeries(
       entry,
@@ -445,6 +465,17 @@ export default function transformProps(
     xAxisDataType === GenericDataType.Temporal
       ? getXAxisFormatter(xAxisTimeFormat)
       : String;
+
+  const anomalyScatterSeries = processAnomaliesForChart(
+    rawSeries as RawSeriesEntry[],
+    inverted,
+    anomalyLookup,
+    tooltipFormatter,
+    refs,
+    inContextMenu || false,
+    theme,
+  );
+  series.push(...anomalyScatterSeries);
 
   const {
     setDataMask = () => {},

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -63,6 +63,12 @@ export type EchartsTimeseriesFormData = QueryFormData & {
   forecastSeasonalityDaily: null;
   forecastSeasonalityWeekly: null;
   forecastSeasonalityYearly: null;
+  anomalyDetectionEnabled: boolean;
+  anomalyDetectionContaminationRate: number;
+  anomalyDetectionDetrend: boolean;
+  anomalyDetectionYearlySeasonality: boolean;
+  anomalyDetectionMonthlySeasonality: boolean;
+  anomalyDetectionWeeklySeasonality: boolean;
   logAxis: boolean;
   markerEnabled: boolean;
   markerSize: number;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -68,20 +68,9 @@ export type RawSeriesEntry = {
   data: DataRow[];
 };
 
-export type AnomalyLabel = {
-  isAnomaly: number;
-  anomalyScore: number;
-};
-
-export type AnomalyPoint = {
-  coord: [string | number, number];
-  value: number;
-  tooltip: string;
-};
-
 export type AnomalyLookup = Record<
   string, // series name
-  Record<string | number, AnomalyLabel> // x-coordinate -> anomaly label
+  Record<string | number, { y: number; score: number }> // x-value -> {y-value, anomaly score}
 >;
 
 export enum ForecastSeriesEnum {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -70,7 +70,7 @@ export type RawSeriesEntry = {
 
 export type AnomalyLookup = Record<
   string, // series name
-  Record<string | number, { y: number; score: number }> // x-value -> {y-value, anomaly score}
+  Map<string | number, { y: number; score: number }> // x-value -> {y-value, anomaly score}
 >;
 
 export enum ForecastSeriesEnum {

--- a/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/types.ts
@@ -61,6 +61,29 @@ export interface EchartsHandler {
   getEchartInstance: () => EChartsType | undefined;
 }
 
+export type DataRow = [x: string | number, y: number, ...rest: any[]];
+
+export type RawSeriesEntry = {
+  name: string;
+  data: DataRow[];
+};
+
+export type AnomalyLabel = {
+  isAnomaly: number;
+  anomalyScore: number;
+};
+
+export type AnomalyPoint = {
+  coord: [string | number, number];
+  value: number;
+  tooltip: string;
+};
+
+export type AnomalyLookup = Record<
+  string, // series name
+  Record<string | number, AnomalyLabel> // x-coordinate -> anomaly label
+>;
+
 export enum ForecastSeriesEnum {
   Observation = '',
   ForecastTrend = '__yhat',

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -1,13 +1,7 @@
 import type { ScatterSeriesOption } from 'echarts';
 import type { SupersetTheme } from '@superset-ui/core';
 import { getDefaultTooltip } from './tooltip';
-import type {
-  Refs,
-  DataRow,
-  RawSeriesEntry,
-  AnomalyLookup,
-  AnomalyPoint,
-} from '../types';
+import type { Refs, RawSeriesEntry, AnomalyLookup } from '../types';
 
 export const ANOMALY_SUFFIXES = {
   IS_ANOMALY: '_is_anomaly',
@@ -16,16 +10,17 @@ export const ANOMALY_SUFFIXES = {
 
 export const ANOMALY_SCORE_THRESHOLDS = {
   HIGH: 0.7,
-  MEDIUM: 0.4,
-  LOW: 0.2,
+  MEDIUM: 0.3,
 } as const;
 
 export const ANOMALY_POINT_CONFIG = {
   baseSize: 6,
   zLevel: 1,
   symbol: 'circle',
-  sizeAdjustmentFactor: 5,
+  sizeAdjustmentFactor: 4,
 } as const;
+
+export const DEFAULT_ANOMALY_SCORE = 0.5;
 
 // the following two functions dynamically adjust the color and size
 // of each anomaly point based on its anomaly score, which we expect to
@@ -35,10 +30,10 @@ export function getAdjustedAnomalyPointColor(
   score: number,
   theme: SupersetTheme,
 ): string {
-  if (score > ANOMALY_SCORE_THRESHOLDS.HIGH) return theme.colors.error.base;
-  if (score > ANOMALY_SCORE_THRESHOLDS.MEDIUM) return theme.colors.warning.base;
-  if (score > ANOMALY_SCORE_THRESHOLDS.LOW) return theme.colors.alert.base;
-  return theme.colors.alert.light1;
+  if (score >= ANOMALY_SCORE_THRESHOLDS.HIGH) return theme.colors.error.base;
+  if (score >= ANOMALY_SCORE_THRESHOLDS.MEDIUM)
+    return theme.colors.warning.base;
+  return theme.colors.alert.base;
 }
 
 export function getAdjustedAnomalyPointSize(
@@ -51,71 +46,6 @@ export function getAdjustedAnomalyPointSize(
   );
 }
 
-export function createAnomalyLookup(
-  rawSeries: RawSeriesEntry[],
-  seriesNameLookup: Record<string, string>,
-): AnomalyLookup {
-  const anomalyLookup: AnomalyLookup = {};
-
-  rawSeries.forEach(entry => {
-    const entryName = String(entry.name || '');
-    const seriesName = seriesNameLookup[entryName] || entryName;
-
-    if (
-      seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY) ||
-      seriesName.endsWith(ANOMALY_SUFFIXES.ANOMALY_SCORE)
-    ) {
-      // remove suffix to get base series name
-      const baseSeriesName = seriesName.replace(
-        new RegExp(
-          `${ANOMALY_SUFFIXES.IS_ANOMALY}$|${ANOMALY_SUFFIXES.ANOMALY_SCORE}$`,
-        ),
-        '',
-      );
-
-      if (!anomalyLookup[baseSeriesName]) {
-        anomalyLookup[baseSeriesName] = {};
-      }
-
-      entry.data.forEach(([x, y]: [string | number, number]) => {
-        if (!anomalyLookup[baseSeriesName][x]) {
-          anomalyLookup[baseSeriesName][x] = { isAnomaly: 0, anomalyScore: 0 };
-        }
-
-        if (seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY)) {
-          anomalyLookup[baseSeriesName][x].isAnomaly = y;
-        } else if (seriesName.endsWith(ANOMALY_SUFFIXES.ANOMALY_SCORE)) {
-          anomalyLookup[baseSeriesName][x].anomalyScore = y;
-        }
-      });
-    }
-  });
-
-  return anomalyLookup;
-}
-
-export function extractAnomaliesForSeries(
-  seriesData: DataRow[],
-  seriesName: string,
-  anomalyLookup: AnomalyLookup,
-): AnomalyPoint[] {
-  const anomalies: AnomalyPoint[] = [];
-  const seriesAnomalyLabel = anomalyLookup[seriesName] || {};
-
-  seriesData.forEach(([x, y]: [string | number, number]) => {
-    const anomalyLabel = seriesAnomalyLabel[x];
-    if (anomalyLabel && anomalyLabel.isAnomaly === 1) {
-      anomalies.push({
-        coord: [x, y],
-        value: y,
-        tooltip: `Anomaly Score: ${anomalyLabel.anomalyScore}`,
-      });
-    }
-  });
-
-  return anomalies;
-}
-
 export function isSeriesAboutAnomaly(seriesName: string): boolean {
   return (
     seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY) ||
@@ -123,9 +53,68 @@ export function isSeriesAboutAnomaly(seriesName: string): boolean {
   );
 }
 
+export function createAnomalyLookup(
+  rawSeries: RawSeriesEntry[],
+  seriesNameLookup: Record<string, string>,
+): AnomalyLookup {
+  const seriesLookup = new Map<string, RawSeriesEntry>();
+  rawSeries.forEach(entry => {
+    const entryName = String(entry.name || '');
+    const seriesName = seriesNameLookup[entryName] || entryName;
+    seriesLookup.set(seriesName, entry);
+  });
+
+  const anomalyLookup: AnomalyLookup = {};
+  rawSeries.forEach(entry => {
+    const entryName = String(entry.name || '');
+    const seriesName = seriesNameLookup[entryName] || entryName;
+    if (isSeriesAboutAnomaly(seriesName)) {
+      return;
+    }
+
+    const anomalyFlagSeriesName = `${seriesName}${ANOMALY_SUFFIXES.IS_ANOMALY}`;
+    const anomalyFlagSeries = seriesLookup.get(anomalyFlagSeriesName);
+    if (!anomalyFlagSeries) {
+      return;
+    }
+    // set of x-values for anomalies
+    const anomalyXValues = new Set<string | number>();
+    anomalyFlagSeries.data.forEach(
+      ([x, isAnomaly]: [string | number, number]) => {
+        if (isAnomaly === 1) {
+          anomalyXValues.add(x);
+        }
+      },
+    );
+
+    const anomalyScoreSeriesName = `${seriesName}${ANOMALY_SUFFIXES.ANOMALY_SCORE}`;
+    const anomalyScoreSeries = seriesLookup.get(anomalyScoreSeriesName);
+    // maps x-values to anomaly scores
+    const anomalyScoreLookup = new Map<string | number, number>();
+    if (anomalyScoreSeries) {
+      anomalyScoreSeries.data.forEach(
+        ([x, score]: [string | number, number]) => {
+          anomalyScoreLookup.set(x, score);
+        },
+      );
+    }
+
+    anomalyLookup[seriesName] = {};
+    entry.data.forEach(([x, y]: [string | number, number]) => {
+      if (anomalyXValues.has(x)) {
+        anomalyLookup[seriesName][x] = {
+          y,
+          score: anomalyScoreLookup.get(x) ?? DEFAULT_ANOMALY_SCORE,
+        };
+      }
+    });
+  });
+
+  return anomalyLookup;
+}
+
 export function createAnomalyScatterSeries(
   seriesName: string,
-  anomalies: AnomalyPoint[],
   anomalyLookup: AnomalyLookup,
   tooltipFormatter:
     | ((value: number | Date | null | undefined) => string)
@@ -134,25 +123,27 @@ export function createAnomalyScatterSeries(
   inContextMenu: boolean,
   theme: SupersetTheme,
 ): ScatterSeriesOption {
+  const anomalyData: any[] = [];
+  const seriesAnomalies = anomalyLookup[seriesName] || {};
+
+  Object.entries(seriesAnomalies).forEach(([x, { y, score }]) => {
+    anomalyData.push({
+      value: [x, y],
+      anomalyScore: score,
+      itemStyle: {
+        color: getAdjustedAnomalyPointColor(score, theme),
+      },
+      symbolSize: getAdjustedAnomalyPointSize(
+        score,
+        ANOMALY_POINT_CONFIG.baseSize,
+      ),
+    });
+  });
+
   return {
     name: `${seriesName} - Anomalies`,
     type: 'scatter',
-    data: anomalies.map(a => {
-      const anomalyLabel = anomalyLookup[seriesName]?.[a.coord[0]];
-      const score = anomalyLabel?.anomalyScore || 0;
-
-      return {
-        value: a.coord,
-        anomalyScore: score,
-        itemStyle: {
-          color: getAdjustedAnomalyPointColor(score, theme),
-        },
-        symbolSize: getAdjustedAnomalyPointSize(
-          score,
-          ANOMALY_POINT_CONFIG.baseSize,
-        ),
-      };
-    }),
+    data: anomalyData,
     symbol: ANOMALY_POINT_CONFIG.symbol,
     zlevel: ANOMALY_POINT_CONFIG.zLevel,
     tooltip: {
@@ -162,30 +153,23 @@ export function createAnomalyScatterSeries(
       formatter: (params: any) => {
         const { value, anomalyScore } = params.data;
         const [xValue, yValue] = value;
-        const anomalyLabel = anomalyLookup[seriesName]?.[xValue];
+        const anomalyColor = getAdjustedAnomalyPointColor(anomalyScore, theme);
 
-        if (anomalyLabel) {
-          const anomalyColor = getAdjustedAnomalyPointColor(
-            anomalyScore,
-            theme,
-          );
-          return `
-              <div style="text-align: left; padding: 8px;">
-                <div style="color: ${
-                  theme.colors.error.base
-                }; font-weight: bold; margin-bottom: 4px;">
-                  🚨 Anomaly Detected
-                </div>
-                <div><strong>Series:</strong> ${seriesName}</div>
-                <div><strong>Time:</strong> ${tooltipFormatter(xValue)}</div>
-                <div><strong>Value:</strong> ${yValue.toLocaleString()}</div>
-                <div style="color: ${anomalyColor}; font-weight: bold;">
-                  <strong>Anomaly Score:</strong> ${anomalyScore?.toFixed(3)}
-                </div>
-              </div>
-            `;
-        }
-        return `Anomaly: ${yValue}`;
+        return `
+          <div style="text-align: left; padding: 8px;">
+            <div style="color: ${
+              theme.colors.error.base
+            }; font-weight: bold; margin-bottom: 4px;">
+              🚨 Anomaly Detected
+            </div>
+            <div><strong>Series:</strong> ${seriesName}</div>
+            <div><strong>Time:</strong> ${tooltipFormatter(xValue)}</div>
+            <div><strong>Value:</strong> ${yValue.toLocaleString()}</div>
+            <div style="color: ${anomalyColor}; font-weight: bold;">
+              <strong>Anomaly Score:</strong> ${anomalyScore?.toFixed(3)}
+            </div>
+          </div>
+        `;
       },
     },
   };
@@ -212,22 +196,21 @@ export function processAnomaliesForChart(
       return;
     }
 
-    const anomalies = extractAnomaliesForSeries(
-      entry.data,
-      seriesName,
-      anomalyLookup,
-    );
-    if (anomalies.length > 0) {
+    if (
+      anomalyLookup[seriesName] &&
+      Object.keys(anomalyLookup[seriesName]).length > 0
+    ) {
       const anomalySeries = createAnomalyScatterSeries(
         seriesName,
-        anomalies,
         anomalyLookup,
         tooltipFormatter,
         refs,
         inContextMenu,
         theme,
       );
-      anomalyScatterSeries.push(anomalySeries);
+      if (anomalySeries.data && anomalySeries.data.length > 0) {
+        anomalyScatterSeries.push(anomalySeries);
+      }
     }
   });
 

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -99,13 +99,13 @@ export function createAnomalyLookup(
       );
     }
 
-    anomalyLookup[seriesName] = {};
+    anomalyLookup[seriesName] = new Map();
     entry.data.forEach(([x, y]: [string | number, number]) => {
       if (anomalyXValues.has(x)) {
-        anomalyLookup[seriesName][x] = {
+        anomalyLookup[seriesName].set(x, {
           y,
           score: anomalyScoreLookup.get(x) ?? DEFAULT_ANOMALY_SCORE,
-        };
+        });
       }
     });
   });
@@ -124,9 +124,9 @@ export function createAnomalyScatterSeries(
   theme: SupersetTheme,
 ): ScatterSeriesOption {
   const anomalyData: any[] = [];
-  const seriesAnomalies = anomalyLookup[seriesName] || {};
+  const seriesAnomalies = anomalyLookup[seriesName] || new Map();
 
-  Object.entries(seriesAnomalies).forEach(([x, { y, score }]) => {
+  seriesAnomalies.forEach(({ y, score }, x) => {
     anomalyData.push({
       value: [x, y],
       anomalyScore: score,
@@ -198,7 +198,7 @@ export function processAnomaliesForChart(
 
     if (
       anomalyLookup[seriesName] &&
-      Object.keys(anomalyLookup[seriesName]).length > 0
+      anomalyLookup[seriesName].size > 0
     ) {
       const anomalySeries = createAnomalyScatterSeries(
         seriesName,

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -1,0 +1,235 @@
+import type { ScatterSeriesOption } from 'echarts';
+import type { SupersetTheme } from '@superset-ui/core';
+import { getDefaultTooltip } from './tooltip';
+import type {
+  Refs,
+  DataRow,
+  RawSeriesEntry,
+  AnomalyLookup,
+  AnomalyPoint,
+} from '../types';
+
+export const ANOMALY_SUFFIXES = {
+  IS_ANOMALY: '_is_anomaly',
+  ANOMALY_SCORE: '_anomaly_score',
+} as const;
+
+export const ANOMALY_SCORE_THRESHOLDS = {
+  HIGH: 0.7,
+  MEDIUM: 0.4,
+  LOW: 0.2,
+} as const;
+
+export const ANOMALY_POINT_CONFIG = {
+  baseSize: 6,
+  zLevel: 1,
+  symbol: 'circle',
+  sizeAdjustmentFactor: 5,
+} as const;
+
+// the following two functions dynamically adjust the color and size
+// of each anomaly point based on its anomaly score, which we expect to
+// have already been normalized to between 0 and 1
+
+export function getAdjustedAnomalyPointColor(
+  score: number,
+  theme: SupersetTheme,
+): string {
+  if (score > ANOMALY_SCORE_THRESHOLDS.HIGH) return theme.colors.error.base;
+  if (score > ANOMALY_SCORE_THRESHOLDS.MEDIUM) return theme.colors.warning.base;
+  if (score > ANOMALY_SCORE_THRESHOLDS.LOW) return theme.colors.alert.base;
+  return theme.colors.alert.light1;
+}
+
+export function getAdjustedAnomalyPointSize(
+  score: number,
+  baseSize: number,
+): number {
+  return Math.max(
+    baseSize,
+    baseSize + score * ANOMALY_POINT_CONFIG.sizeAdjustmentFactor,
+  );
+}
+
+export function createAnomalyLookup(
+  rawSeries: RawSeriesEntry[],
+  seriesNameLookup: Record<string, string>,
+): AnomalyLookup {
+  const anomalyLookup: AnomalyLookup = {};
+
+  rawSeries.forEach(entry => {
+    const entryName = String(entry.name || '');
+    const seriesName = seriesNameLookup[entryName] || entryName;
+
+    if (
+      seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY) ||
+      seriesName.endsWith(ANOMALY_SUFFIXES.ANOMALY_SCORE)
+    ) {
+      // remove suffix to get base series name
+      const baseSeriesName = seriesName.replace(
+        new RegExp(
+          `${ANOMALY_SUFFIXES.IS_ANOMALY}$|${ANOMALY_SUFFIXES.ANOMALY_SCORE}$`,
+        ),
+        '',
+      );
+
+      if (!anomalyLookup[baseSeriesName]) {
+        anomalyLookup[baseSeriesName] = {};
+      }
+
+      entry.data.forEach(([x, y]: [string | number, number]) => {
+        if (!anomalyLookup[baseSeriesName][x]) {
+          anomalyLookup[baseSeriesName][x] = { isAnomaly: 0, anomalyScore: 0 };
+        }
+
+        if (seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY)) {
+          anomalyLookup[baseSeriesName][x].isAnomaly = y;
+        } else if (seriesName.endsWith(ANOMALY_SUFFIXES.ANOMALY_SCORE)) {
+          anomalyLookup[baseSeriesName][x].anomalyScore = y;
+        }
+      });
+    }
+  });
+
+  return anomalyLookup;
+}
+
+export function extractAnomaliesForSeries(
+  seriesData: DataRow[],
+  seriesName: string,
+  anomalyLookup: AnomalyLookup,
+): AnomalyPoint[] {
+  const anomalies: AnomalyPoint[] = [];
+  const seriesAnomalyLabel = anomalyLookup[seriesName] || {};
+
+  seriesData.forEach(([x, y]: [string | number, number]) => {
+    const anomalyLabel = seriesAnomalyLabel[x];
+    if (anomalyLabel && anomalyLabel.isAnomaly === 1) {
+      anomalies.push({
+        coord: [x, y],
+        value: y,
+        tooltip: `Anomaly Score: ${anomalyLabel.anomalyScore}`,
+      });
+    }
+  });
+
+  return anomalies;
+}
+
+export function isSeriesAboutAnomaly(seriesName: string): boolean {
+  return (
+    seriesName.endsWith(ANOMALY_SUFFIXES.IS_ANOMALY) ||
+    seriesName.endsWith(ANOMALY_SUFFIXES.ANOMALY_SCORE)
+  );
+}
+
+export function createAnomalyScatterSeries(
+  seriesName: string,
+  anomalies: AnomalyPoint[],
+  anomalyLookup: AnomalyLookup,
+  tooltipFormatter:
+    | ((value: number | Date | null | undefined) => string)
+    | ((value: string | number) => string),
+  refs: Refs,
+  inContextMenu: boolean,
+  theme: SupersetTheme,
+): ScatterSeriesOption {
+  return {
+    name: `${seriesName} - Anomalies`,
+    type: 'scatter',
+    data: anomalies.map(a => {
+      const anomalyLabel = anomalyLookup[seriesName]?.[a.coord[0]];
+      const score = anomalyLabel?.anomalyScore || 0;
+
+      return {
+        value: a.coord,
+        anomalyScore: score,
+        itemStyle: {
+          color: getAdjustedAnomalyPointColor(score, theme),
+        },
+        symbolSize: getAdjustedAnomalyPointSize(
+          score,
+          ANOMALY_POINT_CONFIG.baseSize,
+        ),
+      };
+    }),
+    symbol: ANOMALY_POINT_CONFIG.symbol,
+    zlevel: ANOMALY_POINT_CONFIG.zLevel,
+    tooltip: {
+      ...getDefaultTooltip(refs),
+      show: !inContextMenu,
+      trigger: 'item',
+      formatter: (params: any) => {
+        const { value, anomalyScore } = params.data;
+        const [xValue, yValue] = value;
+        const anomalyLabel = anomalyLookup[seriesName]?.[xValue];
+
+        if (anomalyLabel) {
+          const anomalyColor = getAdjustedAnomalyPointColor(
+            anomalyScore,
+            theme,
+          );
+          return `
+              <div style="text-align: left; padding: 8px;">
+                <div style="color: ${
+                  theme.colors.error.base
+                }; font-weight: bold; margin-bottom: 4px;">
+                  🚨 Anomaly Detected
+                </div>
+                <div><strong>Series:</strong> ${seriesName}</div>
+                <div><strong>Time:</strong> ${tooltipFormatter(xValue)}</div>
+                <div><strong>Value:</strong> ${yValue.toLocaleString()}</div>
+                <div style="color: ${anomalyColor}; font-weight: bold;">
+                  <strong>Anomaly Score:</strong> ${anomalyScore?.toFixed(3)}
+                </div>
+              </div>
+            `;
+        }
+        return `Anomaly: ${yValue}`;
+      },
+    },
+  };
+}
+
+export function processAnomaliesForChart(
+  rawSeries: RawSeriesEntry[],
+  seriesNameLookup: Record<string, string>,
+  anomalyLookup: AnomalyLookup,
+  tooltipFormatter:
+    | ((value: number | Date | null | undefined) => string)
+    | ((value: string | number) => string),
+  refs: Refs,
+  inContextMenu: boolean,
+  theme: SupersetTheme,
+): ScatterSeriesOption[] {
+  const anomalyScatterSeries: ScatterSeriesOption[] = [];
+
+  rawSeries.forEach(entry => {
+    const entryName = String(entry.name || '');
+    const seriesName = seriesNameLookup[entryName] || entryName;
+
+    if (isSeriesAboutAnomaly(seriesName)) {
+      return;
+    }
+
+    const anomalies = extractAnomaliesForSeries(
+      entry.data,
+      seriesName,
+      anomalyLookup,
+    );
+    if (anomalies.length > 0) {
+      const anomalySeries = createAnomalyScatterSeries(
+        seriesName,
+        anomalies,
+        anomalyLookup,
+        tooltipFormatter,
+        refs,
+        inContextMenu,
+        theme,
+      );
+      anomalyScatterSeries.push(anomalySeries);
+    }
+  });
+
+  return anomalyScatterSeries;
+}

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -196,10 +196,7 @@ export function processAnomaliesForChart(
       return;
     }
 
-    if (
-      anomalyLookup[seriesName] &&
-      anomalyLookup[seriesName].size > 0
-    ) {
+    if (anomalyLookup[seriesName] && anomalyLookup[seriesName].size > 0) {
       const anomalySeries = createAnomalyScatterSeries(
         seriesName,
         anomalyLookup,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
@@ -114,12 +114,9 @@ describe('anomalyDetection utils', () => {
       };
 
       const lookup = createAnomalyLookup(rawSeries, seriesNameLookup);
-      expect(lookup).toEqual({
-        metric1: {
-          '2025-01-02': { y: 200, score: 0.8 },
-        },
-        metric2: {},
-      });
+      expect(lookup.metric1.size).toBe(1);
+      expect(lookup.metric1.get('2025-01-02')).toEqual({ y: 200, score: 0.8 });
+      expect(lookup.metric2.size).toBe(0);
     });
 
     it('should use default anomaly score when score series is missing', () => {
@@ -144,22 +141,22 @@ describe('anomalyDetection utils', () => {
         metric1_is_anomaly: 'metric1_is_anomaly',
       };
       const lookup = createAnomalyLookup(rawSeries, seriesNameLookup);
-      expect(lookup).toEqual({
-        metric1: {
-          '2025-01-02': { y: 200, score: DEFAULT_ANOMALY_SCORE },
-        },
+      expect(lookup.metric1.size).toBe(1);
+      expect(lookup.metric1.get('2025-01-02')).toEqual({
+        y: 200,
+        score: DEFAULT_ANOMALY_SCORE,
       });
     });
   });
 
   describe('createAnomalyScatterSeries', () => {
     const anomalyLookup: AnomalyLookup = {
-      metric1: {
-        '2025-01-01': { y: 100, score: 0.8 },
-        '2025-01-03': { y: 50, score: 0.5 },
-        '2025-01-10': { y: 35, score: 0.1 },
-      },
-      metric2: {},
+      metric1: new Map([
+        ['2025-01-01', { y: 100, score: 0.8 }],
+        ['2025-01-03', { y: 50, score: 0.5 }],
+        ['2025-01-10', { y: 35, score: 0.1 }],
+      ]),
+      metric2: new Map(),
     };
 
     it('should create scatter series with correct data', () => {
@@ -196,7 +193,7 @@ describe('anomalyDetection utils', () => {
       expect(dataPoint3.symbolSize).toBe(6 + 0.1 * 4);
     });
 
-    it('should handle empty record in anomaly lookup', () => {
+    it('should handle empty map in anomaly lookup', () => {
       const series = createAnomalyScatterSeries(
         'metric2',
         anomalyLookup,

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
@@ -1,0 +1,273 @@
+import { SupersetTheme } from '@superset-ui/core';
+import {
+  ANOMALY_POINT_CONFIG,
+  DEFAULT_ANOMALY_SCORE,
+  isSeriesAboutAnomaly,
+  createAnomalyLookup,
+  createAnomalyScatterSeries,
+  processAnomaliesForChart,
+} from '../../src/utils/anomalyDetection';
+import type { RawSeriesEntry, AnomalyLookup, Refs } from '../../src/types';
+
+const mockTheme: SupersetTheme = {
+  colors: {
+    error: { base: '#ff4d4f' },
+    warning: { base: '#faad14' },
+    alert: { base: '#52c41a' },
+  },
+} as SupersetTheme;
+
+const mockRefs: Refs = {
+  echartRef: { current: null },
+  divRef: { current: null },
+};
+
+const mockTooltipFormatter = (value: string | number) => String(value);
+
+describe('anomalyDetection utils', () => {
+  describe('isSeriesAboutAnomaly', () => {
+    it('should return true for anomaly flag series', () => {
+      expect(isSeriesAboutAnomaly('metric1_is_anomaly')).toBe(true);
+    });
+
+    it('should return true for anomaly score series', () => {
+      expect(isSeriesAboutAnomaly('metric1_anomaly_score')).toBe(true);
+    });
+
+    it('should return false for regular series', () => {
+      expect(isSeriesAboutAnomaly('metric1')).toBe(false);
+    });
+
+    it('should return false for series that partially match suffixes', () => {
+      expect(isSeriesAboutAnomaly('metric1_is_anomaly_extra')).toBe(false);
+      expect(isSeriesAboutAnomaly('metric1_anomaly_score_extra')).toBe(false);
+    });
+  });
+
+  describe('createAnomalyLookup', () => {
+    it('should create empty lookup when no anomaly series exist', () => {
+      const rawSeries: RawSeriesEntry[] = [
+        {
+          name: 'metric1',
+          data: [
+            ['2025-01-01', 100],
+            ['2025-01-02', 200],
+          ],
+        },
+      ];
+      const seriesNameLookup = { metric1: 'metric1' };
+
+      const lookup = createAnomalyLookup(rawSeries, seriesNameLookup);
+      expect(lookup).toEqual({});
+    });
+
+    it('should create lookup for series with anomalies', () => {
+      const rawSeries: RawSeriesEntry[] = [
+        {
+          name: 'metric1',
+          data: [
+            ['2025-01-01', 100],
+            ['2025-01-02', 200],
+          ],
+        },
+        {
+          name: 'metric1_is_anomaly',
+          data: [
+            ['2025-01-01', 0],
+            ['2025-01-02', 1],
+          ],
+        },
+        {
+          name: 'metric1_anomaly_score',
+          data: [
+            ['2025-01-01', 0],
+            ['2025-01-02', 0.8],
+          ],
+        },
+        {
+          name: 'metric2',
+          data: [
+            ['2025-01-01', 50],
+            ['2025-01-02', 50],
+          ],
+        },
+        {
+          name: 'metric2_is_anomaly',
+          data: [
+            // no anomalies detected
+            ['2025-01-01', 0],
+            ['2025-01-02', 0],
+          ],
+        },
+        {
+          name: 'metric2_anomaly_score',
+          data: [
+            ['2025-01-01', 0],
+            ['2025-01-02', 0],
+          ],
+        },
+      ];
+      const seriesNameLookup = {
+        metric1: 'metric1',
+        metric1_is_anomaly: 'metric1_is_anomaly',
+        metric1_anomaly_score: 'metric1_anomaly_score',
+      };
+
+      const lookup = createAnomalyLookup(rawSeries, seriesNameLookup);
+      expect(lookup).toEqual({
+        metric1: {
+          '2025-01-02': { y: 200, score: 0.8 },
+        },
+        metric2: {},
+      });
+    });
+
+    it('should use default anomaly score when score series is missing', () => {
+      const rawSeries: RawSeriesEntry[] = [
+        {
+          name: 'metric1',
+          data: [
+            ['2025-01-01', 100],
+            ['2025-01-02', 200],
+          ],
+        },
+        {
+          name: 'metric1_is_anomaly',
+          data: [
+            ['2025-01-01', 0],
+            ['2025-01-02', 1],
+          ],
+        },
+      ];
+      const seriesNameLookup = {
+        metric1: 'metric1',
+        metric1_is_anomaly: 'metric1_is_anomaly',
+      };
+      const lookup = createAnomalyLookup(rawSeries, seriesNameLookup);
+      expect(lookup).toEqual({
+        metric1: {
+          '2025-01-02': { y: 200, score: DEFAULT_ANOMALY_SCORE },
+        },
+      });
+    });
+  });
+
+  describe('createAnomalyScatterSeries', () => {
+    const anomalyLookup: AnomalyLookup = {
+      metric1: {
+        '2025-01-01': { y: 100, score: 0.8 },
+        '2025-01-03': { y: 50, score: 0.5 },
+        '2025-01-10': { y: 35, score: 0.1 },
+      },
+      metric2: {},
+    };
+
+    it('should create scatter series with correct data', () => {
+      const series = createAnomalyScatterSeries(
+        'metric1',
+        anomalyLookup,
+        mockTooltipFormatter,
+        mockRefs,
+        false,
+        mockTheme,
+      );
+
+      expect(series.type).toBe('scatter');
+      expect(series.symbol).toBe(ANOMALY_POINT_CONFIG.symbol);
+      expect(series.zlevel).toBe(ANOMALY_POINT_CONFIG.zLevel);
+      expect(series.data).toHaveLength(3);
+
+      const dataPoint1 = series.data![0] as any;
+      expect(dataPoint1.value).toEqual(['2025-01-01', 100]);
+      expect(dataPoint1.anomalyScore).toBe(0.8);
+      expect(dataPoint1.itemStyle.color).toBe(mockTheme.colors.error.base);
+      expect(dataPoint1.symbolSize).toBe(6 + 0.8 * 4);
+
+      const dataPoint2 = series.data![1] as any;
+      expect(dataPoint2.value).toEqual(['2025-01-03', 50]);
+      expect(dataPoint2.anomalyScore).toBe(0.5);
+      expect(dataPoint2.itemStyle.color).toBe(mockTheme.colors.warning.base);
+      expect(dataPoint2.symbolSize).toBe(6 + 0.5 * 4);
+
+      const dataPoint3 = series.data![2] as any;
+      expect(dataPoint3.value).toEqual(['2025-01-10', 35]);
+      expect(dataPoint3.anomalyScore).toBe(0.1);
+      expect(dataPoint3.itemStyle.color).toBe(mockTheme.colors.alert.base);
+      expect(dataPoint3.symbolSize).toBe(6 + 0.1 * 4);
+    });
+
+    it('should handle empty record in anomaly lookup', () => {
+      const series = createAnomalyScatterSeries(
+        'metric2',
+        anomalyLookup,
+        mockTooltipFormatter,
+        mockRefs,
+        false,
+        mockTheme,
+      );
+
+      expect(series.data).toEqual([]);
+    });
+
+    it('should handle empty anomaly lookup', () => {
+      const series = createAnomalyScatterSeries(
+        'metric1',
+        {},
+        mockTooltipFormatter,
+        mockRefs,
+        false,
+        mockTheme,
+      );
+
+      expect(series.data).toEqual([]);
+    });
+  });
+
+  describe('processAnomaliesForChart', () => {
+    const rawSeries: RawSeriesEntry[] = [
+      {
+        name: 'metric1',
+        data: [
+          ['2025-01-01', 100],
+          ['2025-01-02', 200],
+        ],
+      },
+      {
+        name: 'metric1_is_anomaly',
+        data: [
+          ['2025-01-01', 1],
+          ['2025-01-02', 1],
+        ],
+      },
+      {
+        name: 'metric1_anomaly_score',
+        data: [
+          ['2025-01-01', 0.8],
+          ['2025-01-02', 0.2],
+        ],
+      },
+      { name: 'metric2', data: [['2025-01-01', 300]] },
+      { name: 'metric2_is_anomaly', data: [['2025-01-01', 1]] }, // missing anomaly score series
+      { name: 'metric3', data: [['2025-01-01', 60]] },
+      { name: 'metric3_is_anomaly', data: [['2025-01-01', 0]] }, // no anomalies
+      { name: 'metric3_anomaly_score', data: [['2025-01-01', 0]] },
+      { name: 'metric4', data: [] }, // empty data series
+      { name: 'metric5', data: [['2025-01-01', 500]] }, // no associated anomaly series
+    ];
+    it('should correctly process multiple series with anomalies', () => {
+      const scatterSeries = processAnomaliesForChart(
+        rawSeries,
+        {},
+        createAnomalyLookup(rawSeries, {}),
+        mockTooltipFormatter,
+        mockRefs,
+        false,
+        mockTheme,
+      );
+
+      expect(scatterSeries).toHaveLength(2);
+      expect(scatterSeries[0].name).toBe('metric1 - Anomalies');
+      expect(scatterSeries[1].name).toBe('metric2 - Anomalies');
+    });
+  });
+});

--- a/superset/config.py
+++ b/superset/config.py
@@ -36,7 +36,7 @@ from collections import OrderedDict
 from datetime import timedelta
 from email.mime.multipart import MIMEMultipart
 from importlib.resources import files
-from typing import Any, Callable, Literal, TYPE_CHECKING, TypedDict
+from typing import Any, Callable, Literal, TYPE_CHECKING, TypedDict, Optional
 
 import click
 import pkg_resources
@@ -46,6 +46,7 @@ from flask_appbuilder.security.manager import AUTH_DB
 from flask_caching.backends.base import BaseCache
 from pandas import Series
 from pandas._libs.parsers import STR_NA_VALUES
+from pandas import DataFrame
 from sqlalchemy.engine.url import URL
 from sqlalchemy.orm.query import Query
 
@@ -1880,6 +1881,20 @@ class ExtraDynamicQueryFilters(TypedDict, total=False):
 
 EXTRA_DYNAMIC_QUERY_FILTERS: ExtraDynamicQueryFilters = {}
 
+# plug in your own anomaly detection function here
+# see superset/utils/pandas_postprocessing/anomaly_detection.py for parameter descriptions
+ANOMALY_DETECTION: Optional[Callable[
+    [
+        DataFrame,
+        float,
+        Optional[bool],
+        Optional[bool],
+        Optional[bool],
+        Optional[bool],
+        Optional[str],
+    ],
+    DataFrame,
+]] = None
 
 # -------------------------------------------------------------------
 # *                WARNING:  STOP EDITING  HERE                    *

--- a/superset/utils/pandas_postprocessing/__init__.py
+++ b/superset/utils/pandas_postprocessing/__init__.py
@@ -29,6 +29,7 @@ from superset.utils.pandas_postprocessing.geography import (
 from superset.utils.pandas_postprocessing.histogram import histogram
 from superset.utils.pandas_postprocessing.pivot import pivot
 from superset.utils.pandas_postprocessing.prophet import prophet
+from superset.utils.pandas_postprocessing.anomaly_detection import anomaly_detection
 from superset.utils.pandas_postprocessing.rank import rank
 from superset.utils.pandas_postprocessing.rename import rename
 from superset.utils.pandas_postprocessing.resample import resample
@@ -53,6 +54,7 @@ __all__ = [
     "histogram",
     "pivot",
     "prophet",
+    "anomaly_detection",
     "rank",
     "rename",
     "resample",

--- a/superset/utils/pandas_postprocessing/anomaly_detection.py
+++ b/superset/utils/pandas_postprocessing/anomaly_detection.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from typing import Optional
+
+from superset.config import ANOMALY_DETECTION
+
+def anomaly_detection(
+    df: pd.DataFrame,
+    contamination_rate: float,
+    detrend: Optional[bool] = True,
+    yearly_seasonality: Optional[bool] = True,
+    monthly_seasonality: Optional[bool] = True,
+    weekly_seasonality: Optional[bool] = False,
+    index: Optional[str] = None,
+) -> pd.DataFrame:
+    """
+    Performs anomaly detection on each series in the time-series DataFrame.
+    For each series, adds two new columns suffixed as follows:
+    
+    - `__is_anomaly`: 1 if the data point is an anomaly, 0 if otherwise
+    - `__anomaly_score`: anomaly score for the data point, normalized between 0 and 1; 0 if not an anomaly
+
+    :param df: DataFrame containing time-series data
+    :param contamination_rate: the proportion of data points per series that could be anomalies
+    :param detrend: whether to detrend each series before detecting anomalies
+    :param yearly_seasonality: whether to account for yearly seasonality in each series
+    :param monthly_seasonality: whether to account for monthly seasonality in each series
+    :param weekly_seasonality: whether to account for weekly seasonality in each series
+    :param index: the name of the column containing the x-axis data
+    :return: DataFrame with anomaly detection results, with temporal column at beginning if present
+    """
+    if not ANOMALY_DETECTION:
+        raise ValueError("ANOMALY_DETECTION function is not configured.")
+
+    df = df.copy()
+    index = index or DTTM_ALIAS
+
+    return ANOMALY_DETECTION(df, contamination_rate, detrend, yearly_seasonality,
+                      monthly_seasonality, weekly_seasonality, index)

--- a/superset/utils/pandas_postprocessing/anomaly_detection.py
+++ b/superset/utils/pandas_postprocessing/anomaly_detection.py
@@ -17,7 +17,11 @@ def anomaly_detection(
     For each series, adds two new columns suffixed as follows:
     
     - `__is_anomaly`: 1 if the data point is an anomaly, 0 if otherwise
-    - `__anomaly_score`: anomaly score for the data point, normalized between 0 and 1; 0 if not an anomaly
+    - `__anomaly_score`: anomaly score for each data point, normalized between 0 and 1;
+                         0 if not an anomaly
+
+    The `__anomaly_score` column is technically optional. If not present, all anomalies
+    will be assigned a score of 0.5.
 
     :param df: DataFrame containing time-series data
     :param contamination_rate: the proportion of data points per series that could be anomalies


### PR DESCRIPTION
### SUMMARY

Adds a feature that calls anomaly detection model on time-series data and displays the results.

Supports dynamically adjusting the size and color of each anomaly marker based on anomaly score.

At Pinterest, anomaly detection is performed by a service called Warden (which will be injected as a dependency in the internal repo) but in the public fork, any anomaly detection function that satisfies the parameter requirements could be plugged in.

### TESTING INSTRUCTIONS
Added unit test for anomaly detection util (run `npm test anomalyDetection.test.ts` in `superset/superset-frontend`).

For E2E testing:

Added a dummy anomaly detection function in `superset/config.py` that randomly selects 10 points from each sequence of time-series data as anomalies and assigns them varying ranges of anomaly scores.

Then tried calling anomaly detection on SuperSet UI for both one sequence and multiple sequences of time-series data (displaying as line chart, bar chart, area chart, and scatter plots) and verified that in all cases the correct user arguments are passed into the backend anomaly detection function, and that the results are correctly displayed (see below for an example involving line chart).

<img width="2277" height="1230" alt="superset_anomaly_detection" src="https://github.com/user-attachments/assets/7c153be3-a132-4551-90fa-74b37e070c1b" />

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
