### PR TITLE
fix(dashboard): Move sync charts checkbox under owners section

### DIFF
--- a/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/SyncChartOwnersControl.tsx
@@ -76,7 +76,7 @@ const SyncChartOwnersControl = ({
   const showTooltip = autoSyncChartsEnabled && tooltipText.length > 0;
 
   return (
-    <div data-test="sync-chart-owners-control">
+    <div data-test="sync-chart-owners-control" style={{ marginBottom: '8px'}}>
       <Checkbox
         aria-checked={autoSyncChartsEnabled}
         // aria-labelledby is not being forwarded to the checkbox component.

--- a/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
+++ b/superset-frontend/src/dashboard/components/PropertiesModal/index.tsx
@@ -454,6 +454,7 @@ const PropertiesModal = ({
               'Owners is a list of users who can alter the dashboard. Searchable by name or username.',
             )}
           </p>
+          {getAutoSyncChartsControl()}
         </Col>
         <Col xs={24} md={12}>
           <h3 style={{ marginTop: '1em' }}>{t('Colors')}</h3>
@@ -502,6 +503,7 @@ const PropertiesModal = ({
                 'Owners is a list of users who can alter the dashboard. Searchable by name or username.',
               )}
             </p>
+            {getAutoSyncChartsControl()}
           </Col>
           <Col xs={24} md={12}>
             <StyledFormItem label={t('Roles')}>
@@ -700,7 +702,6 @@ const PropertiesModal = ({
           {isFeatureEnabled(FeatureFlag.DashboardRbac) && canAccessRoles
             ? getRowsWithRoles()
             : getRowsWithoutRoles()}
-          {getAutoSyncChartsControl()}
         </>
         <Row>
           <Col xs={24} md={24}>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Moves the sync charts checkbox to always be under owners.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before:

<img width="866" height="270" alt="Screenshot 2025-08-26 at 2 10 51 PM" src="https://github.com/user-attachments/assets/e9fdd6ff-91ab-4504-be5d-a9404331cf61" />

#### After:
<img width="868" height="260" alt="Screenshot 2025-08-26 at 2 10 06 PM" src="https://github.com/user-attachments/assets/50ef06d2-954e-4063-ae5e-9126503ee39d" />

<img width="828" height="232" alt="Screenshot 2025-08-26 at 2 11 09 PM" src="https://github.com/user-attachments/assets/c0e4b69c-d8d0-41a3-bcb8-41b925058239" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
