### PR TITLE
Remove optionName from chart data cachekey, add option to cache metric values

### DIFF
--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -346,6 +346,27 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             default=str,
         )
 
+    def _remove_option_name_from_cache_dict(self, cache_dict: Any) -> dict[str, Any]:
+        """
+        Recursively search cache_dict and remove any key named 'optionName'.
+        """
+        if isinstance(cache_dict, list):
+            return [
+                self._remove_option_name_from_cache_dict(item) for item in cache_dict
+            ]
+        elif isinstance(cache_dict, tuple):
+            return tuple(
+                self._remove_option_name_from_cache_dict(item) for item in cache_dict
+            )
+        if not isinstance(cache_dict, dict):
+            return cache_dict
+        cache_dict_copy = {}
+        for k in cache_dict:
+            if k == "optionName":
+                continue
+            cache_dict_copy[k] = self._remove_option_name_from_cache_dict(cache_dict[k])
+        return cache_dict_copy
+
     def cache_key(self, **extra: Any) -> str:
         """
         The cache key is made out of the key/values from to_dict(), plus any
@@ -356,6 +377,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
         """
         cache_dict = self.to_dict()
         cache_dict.update(extra)
+        cache_dict = self._remove_option_name_from_cache_dict(cache_dict)
 
         # TODO: the below KVs can all be cleaned up and moved to `to_dict()` at some
         #  predetermined point in time when orgs are aware that the previously

--- a/superset/config.py
+++ b/superset/config.py
@@ -567,6 +567,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # If on, you'll want to add "https://avatars.slack-edge.com" to the list of allowed
     # domains in your TALISMAN_CONFIG
     "SLACK_ENABLE_AVATARS": False,
+    "ENABLE_COLUMN_VALUES_CACHE": True,
 }
 
 # ------------------------------
@@ -1861,6 +1862,8 @@ PINTEREST_WELCOME_TOP_SECTIONS: list[PinterestWelcomeTopSections] | None = []
 # Tag ID used to filter all top dashboards
 PINTEREST_TOP_TAG_ID = 1
 
+# Cache timeout for column values cache (if enabled)
+COLUMN_VALUES_CACHE_TIMEOUT = 25 * 60 * 60  # 25 hours
 
 # Extra dynamic query filters make it possible to limit which objects are shown
 # in the UI before any other filtering is applied. Useful for example when
@@ -1884,16 +1887,16 @@ EXTRA_DYNAMIC_QUERY_FILTERS: ExtraDynamicQueryFilters = {}
 # plug in your own anomaly detection function here
 # see superset/utils/pandas_postprocessing/anomaly_detection.py for parameter descriptions
 ANOMALY_DETECTION: Optional[Callable[
-    [
+        [
+            DataFrame,
+            float,
+            Optional[bool],
+            Optional[bool],
+            Optional[bool],
+            Optional[bool],
+            Optional[str],
+        ],
         DataFrame,
-        float,
-        Optional[bool],
-        Optional[bool],
-        Optional[bool],
-        Optional[bool],
-        Optional[str],
-    ],
-    DataFrame,
 ]] = None
 
 # -------------------------------------------------------------------

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -48,7 +48,11 @@ class DatasourceRestApi(BaseSupersetApi):
         log_to_statsd=False,
     )
     def get_column_values(
-        self, datasource_type: str, datasource_id: int, column_name: str
+        self,
+        datasource_type: str,
+        datasource_id: int,
+        column_name: str,
+        use_cache: bool = False,
     ) -> FlaskResponse:
         """Get possible values for a datasource column.
         ---
@@ -121,6 +125,7 @@ class DatasourceRestApi(BaseSupersetApi):
                 column_name=column_name,
                 limit=row_limit,
                 denormalize_column=denormalize_column,
+                use_cache=use_cache,
             )
             return self.response(200, result=payload)
         except KeyError:

--- a/superset/datasource/api.py
+++ b/superset/datasource/api.py
@@ -16,6 +16,7 @@
 # under the License.
 import logging
 
+from flask import request
 from flask_appbuilder.api import expose, protect, safe
 
 from superset import app, event_logger
@@ -52,7 +53,6 @@ class DatasourceRestApi(BaseSupersetApi):
         datasource_type: str,
         datasource_id: int,
         column_name: str,
-        use_cache: bool = False,
     ) -> FlaskResponse:
         """Get possible values for a datasource column.
         ---
@@ -74,6 +74,12 @@ class DatasourceRestApi(BaseSupersetApi):
               type: string
             name: column_name
             description: The name of the column to get values for
+          - in: query
+            schema:
+              type: boolean
+              default: true
+            name: use_cache
+            description: Whether to use cached results for column values
           responses:
             200:
               description: A List of distinct values for the column
@@ -120,6 +126,7 @@ class DatasourceRestApi(BaseSupersetApi):
 
         row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
         denormalize_column = not datasource.normalize_columns
+        use_cache = request.args.get("use_cache", "false").lower() == "true"
         try:
             payload = datasource.values_for_column(
                 column_name=column_name,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -19,6 +19,7 @@
 
 import builtins
 import dataclasses
+import hashlib
 import logging
 import re
 import uuid
@@ -66,7 +67,7 @@ from superset.exceptions import (
     SupersetParseError,
     SupersetSecurityException,
 )
-from superset.extensions import feature_flag_manager
+from superset.extensions import cache_manager, feature_flag_manager
 from superset.jinja_context import BaseTemplateProcessor
 from superset.sql.parse import SQLScript
 from superset.sql_parse import (
@@ -1321,12 +1322,70 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             )
         return and_(*l)
 
+    def _get_column_values_cache_key(
+        self,
+        column_name: str,
+        limit: int,
+        denormalize_column: bool,
+    ) -> str:
+        """
+        Generate a cache key for column values.
+
+        :param column_name: Name of the column
+        :param limit: Row limit for the query
+        :param denormalize_column: Whether to denormalize column names
+        :return: Cache key string
+        """
+        # Create a unique cache key based on dataset, column, and query parameters
+        cache_key_parts = [
+            str(self.id),  # Dataset ID
+            column_name,
+            str(limit),
+            str(denormalize_column),
+            str(self.fetch_values_predicate),  # Include predicate in cache key
+            str(self.normalize_columns),  # Include normalization setting
+        ]
+
+        # Add RLS filters to cache key if they exist
+        try:
+            tp = self.get_template_processor()
+            rls_filters = self.get_sqla_row_level_filters(template_processor=tp)
+            if rls_filters:
+                # Convert RLS filters to string representation for cache key
+                rls_str = str(sorted([str(f) for f in rls_filters]))
+                cache_key_parts.append(rls_str)
+        except Exception:
+            # If RLS filters can't be determined, don't include them
+            pass
+
+        # Create hash of the cache key parts
+        cache_key_string = "|".join(cache_key_parts)
+        return f"column_values_{hashlib.md5(cache_key_string.encode()).hexdigest()}"
+
     def values_for_column(  # pylint: disable=too-many-locals
         self,
         column_name: str,
         limit: int = 10000,
         denormalize_column: bool = False,
+        use_cache: bool = False,
     ) -> list[Any]:
+        use_column_values_cache = (
+            feature_flag_manager.is_feature_enabled("ENABLE_COLUMN_VALUES_CACHE")
+            and use_cache
+        )
+        # Check cache first if caching is enabled
+        if use_column_values_cache:
+            cache_key = self._get_column_values_cache_key(
+                column_name, limit, denormalize_column
+            )
+            cached_values = cache_manager.explore_form_data_cache.get(cache_key)
+
+            if cached_values is not None:
+                logger.debug(
+                    "Column values retrieved from cache for column: %s", column_name
+                )
+                return cached_values
+
         # denormalize column name before querying for values
         # unless disabled in the dataset configuration
         db_dialect = self.database.get_dialect()
@@ -1372,7 +1431,24 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             df = pd.read_sql_query(sql=sql, con=engine)
             # replace NaN with None to ensure it can be serialized to JSON
             df = df.replace({np.nan: None})
-            return df["column_values"].to_list()
+            column_values = df["column_values"].to_list()
+
+            # Cache the results using explore form data cache if caching is enabled
+            if use_column_values_cache:
+                try:
+                    cache_timeout = app.config.get("COLUMN_VALUES_CACHE_TIMEOUT", 3600)
+                    cache_manager.explore_form_data_cache.set(
+                        cache_key, column_values, timeout=cache_timeout
+                    )
+                except Exception as e:
+                    # Log cache errors but don't fail the request
+                    logger.warning(
+                        "Failed to cache column values for column %s: %s",
+                        column_name,
+                        str(e),
+                    )
+
+            return column_values
 
     def get_timestamp_expression(
         self,

--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -67,7 +67,7 @@ from superset.exceptions import (
     SupersetParseError,
     SupersetSecurityException,
 )
-from superset.extensions import cache_manager, feature_flag_manager
+from superset.extensions import cache_manager, feature_flag_manager, event_logger
 from superset.jinja_context import BaseTemplateProcessor
 from superset.sql.parse import SQLScript
 from superset.sql_parse import (
@@ -813,7 +813,9 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
 
     def get_sqla_row_level_filters(
         self,
-        template_processor: Optional[BaseTemplateProcessor] = None,  # pylint: disable=unused-argument
+        template_processor: Optional[
+            BaseTemplateProcessor
+        ] = None,  # pylint: disable=unused-argument
     ) -> list[TextClause]:
         # TODO: We should refactor this mixin and remove this method
         # as it exists in the BaseDatasource and is not applicable
@@ -1442,6 +1444,17 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
                     )
                 except Exception as e:
                     # Log cache errors but don't fail the request
+                    event_logger.log_with_context(
+                        action=f"column_values_cache_set_failed.{e.__class__.__name__}",
+                        database=self.database,
+                        payload={
+                            "datasource_id": self.id,
+                            "column_name": column_name,
+                            "limit": limit,
+                            "denormalize_column": denormalize_column,
+                            "use_cache": use_cache,
+                        },
+                    )
                     logger.warning(
                         "Failed to cache column values for column %s: %s",
                         column_name,

--- a/superset/tasks/pinterest.py
+++ b/superset/tasks/pinterest.py
@@ -35,3 +35,17 @@ def cache_thumbnails_by_tags(tags: List[str]):
                 dashboard_id=dashboard_id,
                 force=True,
             )
+
+
+@celery_app.task(name="cache_column_values")
+def cache_column_values(datasource_id: int, column_name: str):
+    """This job is used to cache column values for a given datasource and column name."""
+    datasource = DatasourceDAO.get_datasource(datasource_id)
+    row_limit = apply_max_row_limit(app.config["FILTER_SELECT_ROW_LIMIT"])
+    denormalize_column = not datasource.normalize_columns
+    datasource.values_for_column(
+        column_name,
+        limit=row_limit,
+        denormalize_column=denormalize_column,
+        use_cache=True,
+    )

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -145,6 +145,7 @@ class TestDatasourceApi(SupersetTestCase):
             column_name="col2",
             limit=10000,
             denormalize_column=False,
+            use_cache=False,
         )
 
     @pytest.mark.usefixtures("app_context", "virtual_dataset")

--- a/tests/integration_tests/datasource/api_tests.py
+++ b/tests/integration_tests/datasource/api_tests.py
@@ -167,6 +167,7 @@ class TestDatasourceApi(SupersetTestCase):
             column_name="col2",
             limit=10000,
             denormalize_column=True,
+            use_cache=False,
         )
 
     @pytest.mark.usefixtures("app_context", "virtual_dataset")

--- a/tests/unit_tests/models/helpers_test.py
+++ b/tests/unit_tests/models/helpers_test.py
@@ -28,6 +28,9 @@ from pytest_mock import MockerFixture
 from sqlalchemy import create_engine
 from sqlalchemy.orm.session import Session
 from sqlalchemy.pool import StaticPool
+from superset.connectors.sqla.models import SqlaTable, TableColumn
+from superset.extensions import cache_manager
+from tests.unit_tests.conftest import with_feature_flags
 
 if TYPE_CHECKING:
     from superset.models.core import Database
@@ -208,3 +211,142 @@ def test_values_for_column_double_percents(
             ),
             con=engine,
         )
+
+
+@with_feature_flags(ENABLE_COLUMN_VALUES_CACHE=False)
+def test_values_for_column_enable_cache_false(
+    mocker: MockerFixture,
+    database: Database,
+) -> None:
+    """
+    Test that column values are not cached when the feature flag is disabled.
+    """
+    mock_cache = mocker.MagicMock()
+    mocker.patch.object(
+        cache_manager,
+        "_explore_form_data_cache",
+        mock_cache,
+    )
+    mock_cache.get.return_value = None
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a")],
+    )
+    result = table.values_for_column("a", use_cache=True)
+    mock_cache.get.assert_not_called()
+
+
+@with_feature_flags(ENABLE_COLUMN_VALUES_CACHE=True)
+def test_values_for_column_use_cache_false(
+    mocker: MockerFixture,
+    database: Database,
+) -> None:
+    """
+    Test that column values are not cached when use_cache is false.
+    """
+    mock_cache = mocker.MagicMock()
+    mocker.patch.object(
+        cache_manager,
+        "_explore_form_data_cache",
+        mock_cache,
+    )
+    mock_cache.get.return_value = None
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a")],
+    )
+    result = table.values_for_column("a", use_cache=False)
+    mock_cache.get.assert_not_called()
+
+
+@with_feature_flags(ENABLE_COLUMN_VALUES_CACHE=True)
+def test_values_for_column_caching(
+    mocker: MockerFixture,
+    database: Database,
+) -> None:
+    """
+    Test that column values are properly cached and retrieved from cache.
+    """
+
+    # Mock the cache manager
+    mock_cache = mocker.MagicMock()
+    mocker.patch.object(
+        cache_manager,
+        "_explore_form_data_cache",
+        mock_cache,
+    )
+    mock_cache.get.return_value = None
+    # Patch pd.read_sql_query to return [1, None] as the column_values
+    pd = mocker.patch("superset.models.helpers.pd")
+    pd.read_sql_query.return_value = pd.DataFrame(
+        [
+            1,
+            None,
+        ]
+    )
+    pd.read_sql_query.return_value.replace.return_value = pd.read_sql_query.return_value
+    pd.read_sql_query.return_value.__getitem__.return_value.to_list.return_value = [
+        1,
+        None,
+    ]
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a")],
+    )
+
+    # Test cache miss - should query database and cache results
+    result = table.values_for_column("a", use_cache=True)
+
+    assert result == [1, None]
+    mock_cache.get.assert_called_once()
+    mock_cache.set.assert_called_once()
+
+    # Test cache hit - should return cached values without querying database
+    mock_cache.get.return_value = [
+        1,
+        None,
+        2,
+    ]  # Different cached values
+    mock_cache.set.reset_mock()
+
+    result = table.values_for_column("a", use_cache=True)
+    assert result == [1, None, 2]
+    mock_cache.set.assert_not_called()  # Should not set cache again
+
+
+def test_values_for_column_cache_key_generation(
+    mocker: MockerFixture,
+    database: Database,
+) -> None:
+    """
+    Test that cache keys are generated consistently for the same parameters.
+    """
+    from superset.connectors.sqla.models import SqlaTable, TableColumn
+
+    table = SqlaTable(
+        database=database,
+        schema=None,
+        table_name="t",
+        columns=[TableColumn(column_name="a")],
+    )
+
+    # Generate cache keys for the same parameters
+    key1 = table._get_column_values_cache_key("a", 10000, False)
+    key2 = table._get_column_values_cache_key("a", 10000, False)
+
+    # Keys should be identical for identical parameters
+    assert key1 == key2
+
+    # Keys should be different for different parameters
+    key3 = table._get_column_values_cache_key("a", 5000, False)
+    assert key1 != key3
+
+    key4 = table._get_column_values_cache_key("b", 10000, False)
+    assert key1 != key4

--- a/tests/unit_tests/queries/query_object_test.py
+++ b/tests/unit_tests/queries/query_object_test.py
@@ -342,3 +342,157 @@ def test_cache_key_cache_impersonation_on_with_different_user_and_db_impersonati
             ),
         ]
     )
+
+
+class TestRemoveOptionNameFromCacheDict:
+    """Test cases for _remove_option_name_from_cache_dict method"""
+
+    def test_remove_option_name_simple_dict(self):
+        """Test removing optionName from a simple dictionary"""
+        query_object = QueryObject()
+        cache_dict = {
+            "key1": "value1",
+            "optionName": "should_be_removed",
+            "key2": "value2",
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        expected = {"key1": "value1", "key2": "value2"}
+        assert result == expected
+        assert "optionName" not in result
+
+    def test_remove_option_name_nested_dict(self):
+        """Test removing optionName from nested dictionaries"""
+        query_object = QueryObject()
+        cache_dict = {
+            "level1": {"optionName": "should_be_removed", "nested_key": "value"},
+            "level1_2": {"normal_key": "value", "optionName": "also_removed"},
+            "optionName": "removed_too",
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        expected = {
+            "level1": {"nested_key": "value"},
+            "level1_2": {"normal_key": "value"},
+        }
+        assert result == expected
+        assert "optionName" not in result
+        assert "optionName" not in result["level1"]
+        assert "optionName" not in result["level1_2"]
+
+    def test_remove_option_name_with_lists(self):
+        """Test removing optionName from dictionaries within lists"""
+        query_object = QueryObject()
+        cache_dict = {
+            "list_of_dicts": [
+                {"key1": "value1", "optionName": "removed1"},
+                {"key2": "value2", "optionName": "removed2"},
+                {"key3": "value3"},  # no optionName
+            ],
+            "mixed_list": [
+                "string_value",
+                {"optionName": "removed", "key": "value"},
+                42,
+                {"nested": {"optionName": "also_removed", "key": "value"}},
+            ],
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        expected = {
+            "list_of_dicts": [
+                {"key1": "value1"},
+                {"key2": "value2"},
+                {"key3": "value3"},
+            ],
+            "mixed_list": [
+                "string_value",
+                {"key": "value"},
+                42,
+                {"nested": {"key": "value"}},
+            ],
+        }
+        assert result == expected
+
+    def test_remove_option_name_with_tuples(self):
+        """Test removing optionName from dictionaries within tuples"""
+        query_object = QueryObject()
+        cache_dict = {
+            "tuple_of_dicts": (
+                {"key1": "value1", "optionName": "removed1"},
+                {"key2": "value2", "optionName": "removed2"},
+            )
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        expected = {"tuple_of_dicts": ({"key1": "value1"}, {"key2": "value2"})}
+        assert result == expected
+
+    def test_remove_option_name_no_option_name(self):
+        """Test that dictionaries without optionName are unchanged"""
+        query_object = QueryObject()
+        cache_dict = {
+            "key1": "value1",
+            "key2": "value2",
+            "nested": {"nested_key": "nested_value"},
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        assert result == cache_dict
+
+    def test_remove_option_name_empty_dict(self):
+        """Test with empty dictionary"""
+        query_object = QueryObject()
+        cache_dict = {}
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        assert result == {}
+
+    def test_remove_option_name_non_dict_types(self):
+        """Test with non-dictionary types (should return as-is)"""
+        query_object = QueryObject()
+
+        # Test with string
+        assert query_object._remove_option_name_from_cache_dict("string") == "string"
+
+        # Test with integer
+        assert query_object._remove_option_name_from_cache_dict(42) == 42
+
+        # Test with None
+        assert query_object._remove_option_name_from_cache_dict(None) is None
+
+        # Test with list of non-dicts
+        assert query_object._remove_option_name_from_cache_dict([1, 2, 3]) == [1, 2, 3]
+
+    def test_remove_option_name_deeply_nested(self):
+        """Test with deeply nested structures"""
+        query_object = QueryObject()
+        cache_dict = {
+            "level1": {
+                "level2": {
+                    "level3": {"optionName": "deeply_nested_removed", "key": "value"},
+                    "optionName": "level2_removed",
+                },
+                "optionName": "level1_removed",
+            },
+            "optionName": "top_level_removed",
+        }
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        expected = {"level1": {"level2": {"level3": {"key": "value"}}}}
+        assert result == expected
+
+    def test_remove_option_name_only_option_name(self):
+        """Test dictionary with only optionName key"""
+        query_object = QueryObject()
+        cache_dict = {"optionName": "only_key"}
+
+        result = query_object._remove_option_name_from_cache_dict(cache_dict)
+
+        assert result == {}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

- Remove optionName from chart data cachekey (since optionName is a randomly generated value that can differ from chart to chart, or whenever a dataset is being explored & queried). This allows charts that are configured with the same fields to share a cachekey
- Add option to cache column values api result if a param (`use_cache`) is passed. We can allow this api to be cached by default after we implement some ui in the filter selection page to allow users to break the cache.