### PR TITLE
Add pinterest plugin option for custom chart pills

### DIFF
--- a/superset-frontend/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx
@@ -1,0 +1,8 @@
+import { QueryData } from '@superset-ui/core';
+
+export const getPinterestChartPills = (
+  isLoading: boolean,
+  queryResponse: QueryData,
+) => {
+  return <></>;
+};

--- a/superset-frontend/src/explore/components/ChartPills.tsx
+++ b/superset-frontend/src/explore/components/ChartPills.tsx
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { forwardRef, RefObject } from 'react';
+import { forwardRef, RefObject, useMemo } from 'react';
 import { css, QueryData, SupersetTheme } from '@superset-ui/core';
 import RowCountLabel from 'src/explore/components/RowCountLabel';
 import CachedLabel from 'src/components/CachedLabel';
 import Timer from 'src/components/Timer';
 import { Type } from 'src/components/Label';
+import { getPinterestChartPills } from '@pinterest-plugins/src/explore/components/pinterestChartPills';
 
 const CHART_STATUS_MAP = {
   failed: 'danger' as Type,
@@ -52,6 +53,11 @@ export const ChartPills = forwardRef(
   ) => {
     const isLoading = chartStatus === 'loading';
     const firstQueryResponse = queriesResponse?.[0];
+
+    const pinterestChartPills = useMemo(() => {
+      return getPinterestChartPills(isLoading, firstQueryResponse);
+    }, [isLoading, firstQueryResponse]);
+
     return (
       <div ref={ref}>
         <div
@@ -64,6 +70,7 @@ export const ChartPills = forwardRef(
             }
           `}
         >
+          {pinterestChartPills}
           {!isLoading && firstQueryResponse && (
             <RowCountLabel
               rowcount={Number(firstQueryResponse.sql_rowcount) || 0}

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -191,6 +191,10 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/chart-controls/controlMap.stub.ts',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/explore\/components\/pinterestChartPills$/,
+      path.resolve(__dirname, 'pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx'),
+    ),
   );
 }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add option to customize chart pills.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
