### PR TITLE
fix(logging): Fix logging for unexpected chart load errors

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -38,7 +38,7 @@ import {
 } from 'src/explore/exploreUtils';
 import { addDangerToast } from 'src/components/MessageToasts/actions';
 import { logEvent } from 'src/logger/actions';
-import { LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
+import { LOG_ACTIONS_LOAD_CHART, LOG_ACTIONS_LOAD_CHART_FAILED } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
@@ -462,13 +462,9 @@ export function exploreJSON(
         return dispatch(chartUpdateSucceeded(queriesResponse, key));
       })
       .catch(response => {
-        if (isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) {
-          return dispatch(chartUpdateFailed([response], key));
-        }
-
         const appendErrorLog = (errorDetails, isCached) => {
           dispatch(
-            logEvent(LOG_ACTIONS_LOAD_CHART, {
+            logEvent(LOG_ACTIONS_LOAD_CHART_FAILED, {
               slice_id: key,
               has_err: true,
               is_cached: isCached,
@@ -480,17 +476,36 @@ export function exploreJSON(
             }),
           );
         };
+
         if (response.name === 'AbortError') {
           appendErrorLog('abort');
           return dispatch(chartUpdateStopped(key));
         }
-        return getClientErrorObject(response).then(parsedResponse => {
-          if (response.statusText === 'timeout') {
-            appendErrorLog('timeout');
-          } else {
-            appendErrorLog(parsedResponse.error, parsedResponse.is_cached);
+
+        const logAndFail = (parsedResponse, overrideErrorDetails) => {
+          try {
+            const errorDetails =
+              overrideErrorDetails ||
+              parsedResponse?.error ||
+              parsedResponse?.message ||
+              parsedResponse?.statusText ||
+              safeStringify(parsedResponse);
+            appendErrorLog(errorDetails, parsedResponse?.is_cached);
+          } catch (e) {
+            // best-effort logging, ignore secondary errors
           }
           return dispatch(chartUpdateFailed([parsedResponse], key));
+        };
+
+        if (isFeatureEnabled(FeatureFlag.GlobalAsyncQueries)) {
+          return logAndFail(response);
+        }
+
+        return getClientErrorObject(response).then(parsedResponse => {
+          if (response.statusText === 'timeout') {
+            return logAndFail(parsedResponse, 'timeout');
+          }
+          return logAndFail(parsedResponse.error);
         });
       });
 

--- a/superset-frontend/src/logger/LogUtils.ts
+++ b/superset-frontend/src/logger/LogUtils.ts
@@ -18,6 +18,7 @@
  */
 // Log event names ------------------------------------------------------------
 export const LOG_ACTIONS_LOAD_CHART = 'load_chart';
+export const LOG_ACTIONS_LOAD_CHART_FAILED = 'load_chart_failed';
 export const LOG_ACTIONS_RENDER_CHART = 'render_chart';
 export const LOG_ACTIONS_HIDE_BROWSER_TAB = 'hide_browser_tab';
 export const LOG_ACTIONS_LOAD_DASHBOARD_WITH_CHARTS =


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I'm not seeing chart load errors being logged to the database, and having the same action name as the successful `load_chart` event makes them more difficult to find.

Added a new `load_chart_failed` event, and did some refactoring so we can see these get logged while debugging locally without a websocket.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
