### PR TITLE
fix(dashboard): Hide announcements when UI is in standalone mode

### DIFF
--- a/superset-frontend/src/components/AnnouncementBanner/index.tsx
+++ b/superset-frontend/src/components/AnnouncementBanner/index.tsx
@@ -59,9 +59,6 @@ const AnnouncementBanner = () => {
 
   // Hide announcements in standalone views or when navigation is hidden
   const standalone = getUrlParam(URL_PARAMS.standalone);
-  if (standalone || uiConfig.hideNav) {
-    return null;
-  }
 
   // Memoize bootstrap data to prevent re-fetching on every render
   const announcementConfig = useMemo(() => {
@@ -105,6 +102,10 @@ const AnnouncementBanner = () => {
         !dismissedIds.has(announcement.id),
     );
   }, [announcementConfig, dismissedIds]);
+
+  if (standalone || uiConfig.hideNav) {
+    return null;
+  }
 
   if (activeAnnouncements.length === 0) {
     return null;

--- a/superset-frontend/src/components/AnnouncementBanner/index.tsx
+++ b/superset-frontend/src/components/AnnouncementBanner/index.tsx
@@ -21,6 +21,9 @@ import { Alert } from 'antd';
 import { useTheme } from '@superset-ui/core';
 import Icons from 'src/components/Icons';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { getUrlParam } from 'src/utils/urlUtils';
+import { useUiConfig } from 'src/components/UiConfigContext';
+import { URL_PARAMS } from 'src/constants';
 
 interface AnnouncementConfig {
   id: string;
@@ -52,6 +55,13 @@ const AnnouncementBanner = () => {
   );
   const theme = useTheme();
   const { gridUnit } = theme;
+  const uiConfig = useUiConfig();
+
+  // Hide announcements in standalone views or when navigation is hidden
+  const standalone = getUrlParam(URL_PARAMS.standalone);
+  if (standalone || uiConfig.hideNav) {
+    return null;
+  }
 
   // Memoize bootstrap data to prevent re-fetching on every render
   const announcementConfig = useMemo(() => {

--- a/superset-frontend/src/components/AnnouncementBanner/index.tsx
+++ b/superset-frontend/src/components/AnnouncementBanner/index.tsx
@@ -19,6 +19,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { Alert } from 'antd';
 import { useTheme } from '@superset-ui/core';
+import { useLocation } from 'react-router-dom';
 import Icons from 'src/components/Icons';
 import getBootstrapData from 'src/utils/getBootstrapData';
 import { getUrlParam } from 'src/utils/urlUtils';
@@ -57,8 +58,10 @@ const AnnouncementBanner = () => {
   const { gridUnit } = theme;
   const uiConfig = useUiConfig();
 
-  // Hide announcements in standalone views or when navigation is hidden
-  const standalone = getUrlParam(URL_PARAMS.standalone);
+  // useLocation ensures component re-renders on route changes to properly
+  // detect standalone mode from URL params
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const location = useLocation();
 
   // Memoize bootstrap data to prevent re-fetching on every render
   const announcementConfig = useMemo(() => {
@@ -67,6 +70,9 @@ const AnnouncementBanner = () => {
       | AnnouncementConfig[]
       | null;
   }, []);
+
+  // Hide announcements in standalone views or when navigation is hidden
+  const standalone = getUrlParam(URL_PARAMS.standalone);
 
   useEffect(() => {
     // Load dismissed announcements from localStorage on mount

--- a/superset-frontend/src/components/AnnouncementBanner/index.tsx
+++ b/superset-frontend/src/components/AnnouncementBanner/index.tsx
@@ -60,7 +60,6 @@ const AnnouncementBanner = () => {
 
   // useLocation ensures component re-renders on route changes to properly
   // detect standalone mode from URL params
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const location = useLocation();
 
   // Memoize bootstrap data to prevent re-fetching on every render
@@ -72,7 +71,11 @@ const AnnouncementBanner = () => {
   }, []);
 
   // Hide announcements in standalone views or when navigation is hidden
-  const standalone = getUrlParam(URL_PARAMS.standalone);
+  // Re-evaluate when location changes to detect standalone mode from URL params
+  const standalone = useMemo(
+    () => getUrlParam(URL_PARAMS.standalone),
+    [location],
+  );
 
   useEffect(() => {
     // Load dismissed announcements from localStorage on mount


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hide the announcements component when rendering pages in standalone mode, for example rendering dashboards on the home page.

### TESTING
- Navigate to a dashboard with `?standalone=1` with announcements that haven't been dismissed. Verified that announcements are not rendered.
- Not seeing announcements render in dashboard thumbnails on homepage

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
