### PR TITLE
Implement dataset advanced search modal in chart creation

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -40,6 +40,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/visualizations.stub.ts',
     '^@pinterest-plugins/src/chart-controls/controlMap$':
       '<rootDir>/pinterest-plugins/src/chart-controls/controlMap.stub.ts',
+    '^@pinterest-plugins/src/explore/components/pinterestChartPills$':
+      '<rootDir>/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -46218,9 +46218,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "version": "3.7.2",
+      "resolved": "https://artifacts-prod-use1.pinadmin.com/artifactory/api/npm/node-npm-yarn-prod-virtual/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -107436,9 +107436,9 @@
       }
     },
     "luxon": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
-      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ=="
+      "version": "3.7.2",
+      "resolved": "https://artifacts-prod-use1.pinadmin.com/artifactory/api/npm/node-npm-yarn-prod-virtual/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
     },
     "lz-string": {
       "version": "1.5.0",

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.test.tsx
@@ -10,9 +10,6 @@ jest.mock('src/components/TableView', () => {
     onServerPagination,
     loading,
     totalCount,
-    pageSize,
-    initialPageIndex,
-    initialSortBy,
   }: any) {
     return (
       <div data-test="table-view">
@@ -21,22 +18,17 @@ jest.mock('src/components/TableView', () => {
           {data.map((item: any, index: number) => (
             <div key={index} data-test={`table-row-${index}`}>
               <button
+                type="button"
                 data-test="datasource-link"
                 onClick={() => {
                   // Simulate the datasource selection by calling the Cell component
                   const nameColumn = columns.find(
                     (col: any) => col.accessor === 'table_name',
                   );
-                  if (nameColumn && nameColumn.Cell) {
+                  if (nameColumn?.Cell) {
                     const cellProps = { row: { original: item } };
                     const cellElement = nameColumn.Cell(cellProps);
-                    if (
-                      cellElement &&
-                      cellElement.props &&
-                      cellElement.props.onClick
-                    ) {
-                      cellElement.props.onClick();
-                    }
+                    cellElement?.props?.onClick?.();
                   }
                 }}
               >
@@ -64,6 +56,7 @@ jest.mock('src/components/TableView', () => {
         </div>
         <div data-test="pagination">
           <button
+            type="button"
             onClick={() => onServerPagination({ pageIndex: 1, sortBy: [] })}
             data-test="next-page"
           >
@@ -87,26 +80,20 @@ jest.mock('src/components/TableView', () => {
 });
 
 // Mock the Loading component
-jest.mock('src/components/Loading', () => {
-  return function MockLoading() {
-    return <div data-test="loading-component">Loading...</div>;
-  };
-});
+jest.mock('src/components/Loading', () => () => (
+  <div data-test="loading-component">Loading...</div>
+));
 
 // Mock the FacePile component
-jest.mock('src/components/FacePile', () => {
-  return function MockFacePile({ users }: any) {
-    return (
-      <div data-test="face-pile">
-        {users?.map((user: any, index: number) => (
-          <span key={index} data-test={`owner-${index}`}>
-            {user.firstName} {user.lastName}
-          </span>
-        ))}
-      </div>
-    );
-  };
-});
+jest.mock('src/components/FacePile', () => ({ users }: any) => (
+  <div data-test="face-pile">
+    {users?.map((user: any, index: number) => (
+      <span key={index} data-test={`owner-${index}`}>
+        {user.firstName} {user.lastName}
+      </span>
+    ))}
+  </div>
+));
 
 const mockData = [
   {
@@ -219,7 +206,7 @@ describe('DatasetTable', () => {
   });
 
   test('shows loading state', () => {
-    render(<DatasetTable {...defaultProps} loading={true} />);
+    render(<DatasetTable {...defaultProps} loading />);
 
     expect(screen.getByTestId('loading-component')).toBeInTheDocument();
     expect(screen.getByText('Loading...')).toBeInTheDocument();

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.test.tsx
@@ -1,0 +1,362 @@
+import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+
+import DatasetTable from './DatasetTable';
+
+// Mock the TableView component
+jest.mock('src/components/TableView', () => {
+  const MockTableView = function MockTableView({
+    columns,
+    data,
+    onServerPagination,
+    loading,
+    totalCount,
+    pageSize,
+    initialPageIndex,
+    initialSortBy,
+  }: any) {
+    return (
+      <div data-test="table-view">
+        {loading && <div data-test="loading">Loading...</div>}
+        <div data-test="table-data">
+          {data.map((item: any, index: number) => (
+            <div key={index} data-test={`table-row-${index}`}>
+              <button
+                data-test="datasource-link"
+                onClick={() => {
+                  // Simulate the datasource selection by calling the Cell component
+                  const nameColumn = columns.find(
+                    (col: any) => col.accessor === 'table_name',
+                  );
+                  if (nameColumn && nameColumn.Cell) {
+                    const cellProps = { row: { original: item } };
+                    const cellElement = nameColumn.Cell(cellProps);
+                    if (
+                      cellElement &&
+                      cellElement.props &&
+                      cellElement.props.onClick
+                    ) {
+                      cellElement.props.onClick();
+                    }
+                  }
+                }}
+              >
+                {item.table_name}
+              </button>
+              <span data-test={`type-${index}`}>
+                {item.kind === 'physical' ? 'Physical' : 'Virtual'}
+              </span>
+              <span data-test={`schema-${index}`}>{item.schema}</span>
+              <span data-test={`database-${index}`}>
+                {item.database?.database_name}
+              </span>
+              <div data-test={`owners-${index}`}>
+                {item.owners?.map((owner: any, ownerIndex: number) => (
+                  <span
+                    key={ownerIndex}
+                    data-test={`owner-${index}-${ownerIndex}`}
+                  >
+                    {owner.firstName} {owner.lastName}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div data-test="pagination">
+          <button
+            onClick={() => onServerPagination({ pageIndex: 1, sortBy: [] })}
+            data-test="next-page"
+          >
+            Next Page
+          </button>
+        </div>
+        <div data-test="row-count">
+          1-{data.length} of {totalCount}
+        </div>
+      </div>
+    );
+  };
+
+  // Add the EmptyWrapperType enum
+  MockTableView.EmptyWrapperType = {
+    Small: 'Small',
+    Large: 'Large',
+  };
+
+  return MockTableView;
+});
+
+// Mock the Loading component
+jest.mock('src/components/Loading', () => {
+  return function MockLoading() {
+    return <div data-test="loading-component">Loading...</div>;
+  };
+});
+
+// Mock the FacePile component
+jest.mock('src/components/FacePile', () => {
+  return function MockFacePile({ users }: any) {
+    return (
+      <div data-test="face-pile">
+        {users?.map((user: any, index: number) => (
+          <span key={index} data-test={`owner-${index}`}>
+            {user.firstName} {user.lastName}
+          </span>
+        ))}
+      </div>
+    );
+  };
+});
+
+const mockData = [
+  {
+    id: 1,
+    table_name: 'test_table_1',
+    kind: 'physical',
+    schema: 'public',
+    database: { database_name: 'test_db' },
+    owners: [
+      { firstName: 'John', lastName: 'Doe', username: 'john.doe' },
+      { firstName: 'Jane', lastName: 'Smith', username: 'jane.smith' },
+    ],
+  },
+  {
+    id: 2,
+    table_name: 'test_table_2',
+    kind: 'virtual',
+    schema: 'analytics',
+    database: { database_name: 'analytics_db' },
+    owners: [
+      { firstName: 'Bob', lastName: 'Johnson', username: 'bob.johnson' },
+    ],
+  },
+];
+
+const defaultProps = {
+  loading: false,
+  data: mockData,
+  pageSize: 25,
+  pageIndex: 0,
+  sortBy: [{ id: 'table_name', desc: false }],
+  totalCount: 2,
+  onSelectDatasource: jest.fn(),
+  onServerPagination: jest.fn(),
+};
+
+describe('DatasetTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders without crashing', () => {
+    render(<DatasetTable {...defaultProps} />);
+    expect(screen.getByTestId('table-view')).toBeInTheDocument();
+  });
+
+  test('renders dataset data', () => {
+    render(<DatasetTable {...defaultProps} />);
+
+    expect(screen.getByText('test_table_1')).toBeInTheDocument();
+    expect(screen.getByText('test_table_2')).toBeInTheDocument();
+    expect(screen.getByText('Physical')).toBeInTheDocument();
+    expect(screen.getByText('Virtual')).toBeInTheDocument();
+    expect(screen.getByText('public')).toBeInTheDocument();
+    expect(screen.getByText('analytics')).toBeInTheDocument();
+    expect(screen.getByText('test_db')).toBeInTheDocument();
+    expect(screen.getByText('analytics_db')).toBeInTheDocument();
+  });
+
+  test('renders owners using FacePile', () => {
+    render(<DatasetTable {...defaultProps} />);
+
+    expect(screen.getByTestId('owner-0-0')).toHaveTextContent('John Doe');
+    expect(screen.getByTestId('owner-0-1')).toHaveTextContent('Jane Smith');
+    expect(screen.getByTestId('owner-1-0')).toHaveTextContent('Bob Johnson');
+  });
+
+  test('handles dataset selection', () => {
+    const onSelectDatasource = jest.fn();
+    render(
+      <DatasetTable
+        {...defaultProps}
+        onSelectDatasource={onSelectDatasource}
+      />,
+    );
+
+    const firstDatasetLink = screen.getByText('test_table_1');
+    fireEvent.click(firstDatasetLink);
+
+    expect(onSelectDatasource).toHaveBeenCalledWith({
+      type: 'table',
+      id: 1,
+      table_name: 'test_table_1',
+      kind: 'physical',
+      schema: 'public',
+      database: { database_name: 'test_db' },
+      owners: [
+        { firstName: 'John', lastName: 'Doe', username: 'john.doe' },
+        { firstName: 'Jane', lastName: 'Smith', username: 'jane.smith' },
+      ],
+    });
+  });
+
+  test('handles server pagination', () => {
+    const onServerPagination = jest.fn();
+    render(
+      <DatasetTable
+        {...defaultProps}
+        onServerPagination={onServerPagination}
+      />,
+    );
+
+    const nextPageButton = screen.getByTestId('next-page');
+    fireEvent.click(nextPageButton);
+
+    expect(onServerPagination).toHaveBeenCalledWith({
+      pageIndex: 1,
+      sortBy: [],
+    });
+  });
+
+  test('shows loading state', () => {
+    render(<DatasetTable {...defaultProps} loading={true} />);
+
+    expect(screen.getByTestId('loading-component')).toBeInTheDocument();
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('does not show loading when not loading', () => {
+    render(<DatasetTable {...defaultProps} loading={false} />);
+
+    expect(screen.queryByTestId('loading-component')).not.toBeInTheDocument();
+  });
+
+  test('renders correct row count', () => {
+    render(<DatasetTable {...defaultProps} />);
+
+    expect(screen.getByText('1-2 of 2')).toBeInTheDocument();
+  });
+
+  test('handles datasets with missing owners', () => {
+    const dataWithoutOwners = [
+      {
+        id: 3,
+        table_name: 'table_without_owners',
+        kind: 'physical',
+        schema: 'public',
+        database: { database_name: 'test_db' },
+        owners: [],
+      },
+    ];
+
+    render(<DatasetTable {...defaultProps} data={dataWithoutOwners} />);
+
+    expect(screen.getByText('table_without_owners')).toBeInTheDocument();
+    expect(screen.getByTestId('owners-0')).toBeInTheDocument();
+  });
+
+  test('handles datasets with null owners', () => {
+    const dataWithNullOwners = [
+      {
+        id: 4,
+        table_name: 'table_with_null_owners',
+        kind: 'physical',
+        schema: 'public',
+        database: { database_name: 'test_db' },
+        owners: null,
+      },
+    ];
+
+    render(<DatasetTable {...defaultProps} data={dataWithNullOwners} />);
+
+    expect(screen.getByText('table_with_null_owners')).toBeInTheDocument();
+    expect(screen.getByTestId('owners-0')).toBeInTheDocument();
+  });
+
+  test('handles datasets with missing database', () => {
+    const dataWithoutDatabase = [
+      {
+        id: 5,
+        table_name: 'table_without_database',
+        kind: 'physical',
+        schema: 'public',
+        database: null,
+        owners: [],
+      },
+    ];
+
+    render(<DatasetTable {...defaultProps} data={dataWithoutDatabase} />);
+
+    expect(screen.getByText('table_without_database')).toBeInTheDocument();
+  });
+
+  test('renders correct column configuration', () => {
+    render(<DatasetTable {...defaultProps} />);
+
+    // Verify that the table renders with the expected columns
+    expect(screen.getByText('test_table_1')).toBeInTheDocument();
+    expect(screen.getByText('Physical')).toBeInTheDocument();
+    expect(screen.getByText('public')).toBeInTheDocument();
+    expect(screen.getByText('test_db')).toBeInTheDocument();
+  });
+
+  test('handles different sort configurations', () => {
+    const sortByDesc = [{ id: 'table_name', desc: true }];
+    render(<DatasetTable {...defaultProps} sortBy={sortByDesc} />);
+
+    expect(screen.getByTestId('table-view')).toBeInTheDocument();
+  });
+
+  test('handles large total count', () => {
+    render(<DatasetTable {...defaultProps} totalCount={1000} />);
+
+    expect(screen.getByText('1-2 of 1000')).toBeInTheDocument();
+  });
+
+  test('handles datasets with long names', () => {
+    const dataWithLongName = [
+      {
+        id: 7,
+        table_name:
+          'very_long_table_name_that_might_cause_layout_issues_in_the_table_display',
+        kind: 'physical',
+        schema: 'public',
+        database: { database_name: 'test_db' },
+        owners: [],
+      },
+    ];
+
+    render(<DatasetTable {...defaultProps} data={dataWithLongName} />);
+
+    expect(
+      screen.getByText(
+        'very_long_table_name_that_might_cause_layout_issues_in_the_table_display',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('handles multiple owners correctly', () => {
+    const dataWithMultipleOwners = [
+      {
+        id: 8,
+        table_name: 'table_with_many_owners',
+        kind: 'physical',
+        schema: 'public',
+        database: { database_name: 'test_db' },
+        owners: [
+          { firstName: 'Owner1', lastName: 'Last1', username: 'owner1' },
+          { firstName: 'Owner2', lastName: 'Last2', username: 'owner2' },
+          { firstName: 'Owner3', lastName: 'Last3', username: 'owner3' },
+          { firstName: 'Owner4', lastName: 'Last4', username: 'owner4' },
+        ],
+      },
+    ];
+
+    render(<DatasetTable {...defaultProps} data={dataWithMultipleOwners} />);
+
+    expect(screen.getByTestId('owner-0-0')).toHaveTextContent('Owner1 Last1');
+    expect(screen.getByTestId('owner-0-1')).toHaveTextContent('Owner2 Last2');
+    expect(screen.getByTestId('owner-0-2')).toHaveTextContent('Owner3 Last3');
+    expect(screen.getByTestId('owner-0-3')).toHaveTextContent('Owner4 Last4');
+  });
+});

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
 import TableView, { EmptyWrapperType } from 'src/components/TableView';
 import { styled, t } from '@superset-ui/core';
 
 import FacePile from 'src/components/FacePile';
 import Loading from 'src/components/Loading';
+import { useMemo } from 'react';
 
 const TableContainer = styled.div`
   flex: 1;

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasetTable.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo } from 'react';
+import TableView, { EmptyWrapperType } from 'src/components/TableView';
+import { styled, t } from '@superset-ui/core';
+
+import FacePile from 'src/components/FacePile';
+import Loading from 'src/components/Loading';
+
+const TableContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-x: auto;
+
+  .superset-list-view {
+    height: 100%;
+  }
+
+  table {
+    min-width: 800px;
+    table-layout: auto;
+  }
+
+  td,
+  th {
+    white-space: nowrap;
+  }
+
+  td:first-child,
+  th:first-child {
+    min-width: 200px;
+  }
+`;
+
+export interface DatasetTableProps {
+  loading: boolean;
+  data: any[];
+  pageSize: number;
+  pageIndex: number;
+  sortBy: any;
+  totalCount: number;
+  onSelectDatasource: (datasource: any) => void;
+  onServerPagination: (args: any) => void;
+}
+
+const MainContent = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: ${({ theme }) => theme.gridUnit * 5}px;
+  min-height: 0;
+  overflow: hidden;
+`;
+
+const StyledSpan = styled.span`
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.primary.dark1};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.primary.dark2};
+  }
+`;
+
+const DatasetTable: React.FC<DatasetTableProps> = ({
+  loading,
+  data,
+  pageSize,
+  pageIndex,
+  sortBy,
+  totalCount,
+  onSelectDatasource,
+  onServerPagination,
+}) => {
+  const tableColumns = useMemo(
+    () => [
+      {
+        Cell: ({ row: { original } }: any) => (
+          <StyledSpan
+            role="button"
+            tabIndex={0}
+            data-test="datasource-link"
+            onClick={() => onSelectDatasource({ type: 'table', ...original })}
+            style={{
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {original?.table_name}
+          </StyledSpan>
+        ),
+        Header: t('Name'),
+        accessor: 'table_name',
+        minWidth: 200,
+        width: 300,
+      },
+      {
+        Cell: ({
+          row: {
+            original: { kind },
+          },
+        }: any) => (kind === 'physical' ? t('Physical') : t('Virtual')),
+        Header: t('Type'),
+        accessor: 'kind',
+        disableSortBy: true,
+        width: 100,
+      },
+      {
+        Header: t('Schema'),
+        accessor: 'schema',
+        width: 150,
+      },
+      {
+        Header: t('Database'),
+        accessor: 'database.database_name',
+        disableSortBy: true,
+        width: 150,
+      },
+      {
+        Cell: ({
+          row: {
+            original: { owners = [] },
+          },
+        }: any) => <FacePile users={owners} />,
+        Header: t('Owners'),
+        id: 'owners',
+        disableSortBy: true,
+        width: 120,
+      },
+    ],
+    [onSelectDatasource],
+  );
+
+  return (
+    <MainContent>
+      <TableContainer>
+        {loading ? (
+          <Loading />
+        ) : (
+          <TableView
+            columns={tableColumns}
+            data={data}
+            pageSize={pageSize}
+            initialPageIndex={pageIndex}
+            initialSortBy={sortBy}
+            totalCount={totalCount}
+            onServerPagination={onServerPagination}
+            className="table-condensed"
+            emptyWrapperType={EmptyWrapperType.Small}
+            serverPagination
+            isPaginationSticky
+            scrollTable
+          />
+        )}
+      </TableContainer>
+    </MainContent>
+  );
+};
+
+export default DatasetTable;

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.test.tsx
@@ -3,6 +3,7 @@ import {
   UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+import { useListViewResource } from 'src/views/CRUD/hooks';
 
 import DatasourceAdvancedSearchModal from './DatasourceAdvancedSearchModal';
 
@@ -19,10 +20,7 @@ jest.mock('src/views/CRUD/hooks', () => ({
 }));
 
 jest.mock('src/explore/exploreUtils', () => ({
-  useDebouncedEffect: jest.fn((callback, delay, deps) => {
-    // Call the callback immediately for testing
-    callback();
-  }),
+  useDebouncedEffect: jest.fn(callback => callback()),
   formatSelectOptions: jest.fn(options => options),
 }));
 
@@ -32,55 +30,69 @@ jest.mock(
 );
 
 // Mock the child components
-jest.mock('./FilterSidebar', () => {
-  return function MockFilterSidebar({ onFilterChange, onClearFilters }: any) {
-    return (
-      <div data-test="filter-sidebar">
-        <button onClick={() => onFilterChange('table_name', 'test')}>
-          Test Filter
-        </button>
-        <button onClick={() => onFilterChange('certified', true)}>
-          Test Certified Filter
-        </button>
-        <button onClick={onClearFilters}>Clear Filters</button>
-        <button
-          onClick={() => {
-            onFilterChange('table_name', 'test');
-            onFilterChange('certified', true);
-          }}
-        >
-          Test Multiple Filters
-        </button>
-      </div>
-    );
-  };
-});
+jest.mock(
+  './FilterSidebar',
+  () =>
+    function MockFilterSidebar({ onFilterChange, onClearFilters }: any) {
+      return (
+        <div data-test="filter-sidebar">
+          <button
+            type="button"
+            onClick={() => onFilterChange('table_name', 'test')}
+          >
+            Test Filter
+          </button>
+          <button
+            type="button"
+            onClick={() => onFilterChange('certified', true)}
+          >
+            Test Certified Filter
+          </button>
+          <button type="button" onClick={onClearFilters}>
+            Clear Filters
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onFilterChange('table_name', 'test');
+              onFilterChange('certified', true);
+            }}
+          >
+            Test Multiple Filters
+          </button>
+        </div>
+      );
+    },
+);
 
-jest.mock('./DatasetTable', () => {
-  return function MockDatasetTable({
-    onSelectDatasource,
-    onServerPagination,
-  }: any) {
-    return (
-      <div data-test="dataset-table">
-        <button
-          onClick={() =>
-            onSelectDatasource({
-              id: 1,
-              table_name: 'test_table',
-              type: 'table',
-            })
-          }
-        >
-          Select Dataset
-        </button>
-        <button onClick={() => onServerPagination({ pageIndex: 1 })}>
-          Next Page
-        </button>
-      </div>
-    );
-  };
-});
+jest.mock(
+  './DatasetTable',
+  () =>
+    function MockDatasetTable({ onSelectDatasource, onServerPagination }: any) {
+      return (
+        <div data-test="dataset-table">
+          <button
+            type="button"
+            onClick={() =>
+              onSelectDatasource({
+                id: 1,
+                table_name: 'test_table',
+                type: 'table',
+              })
+            }
+          >
+            Select Dataset
+          </button>
+          <button
+            type="button"
+            onClick={() => onServerPagination({ pageIndex: 1 })}
+          >
+            Next Page
+          </button>
+        </div>
+      );
+    },
+);
 
 const mockUser: UserWithPermissionsAndRoles = {
   userId: 1,
@@ -146,9 +158,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('handles filter changes', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -167,9 +178,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('builds filter query correctly for table_name', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -198,9 +208,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('builds filter query correctly for certified filter', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -210,17 +219,22 @@ describe('DatasourceAdvancedSearchModal', () => {
     });
 
     // Mock FilterSidebar to trigger certified filter
-    jest.doMock('./FilterSidebar', () => {
-      return function MockFilterSidebar({ onFilterChange }: any) {
-        return (
-          <div data-testid="filter-sidebar">
-            <button onClick={() => onFilterChange('certified', true)}>
-              Test Certified Filter
-            </button>
-          </div>
-        );
-      };
-    });
+    jest.doMock(
+      './FilterSidebar',
+      () =>
+        function MockFilterSidebar({ onFilterChange }: any) {
+          return (
+            <div data-testid="filter-sidebar">
+              <button
+                type="button"
+                onClick={() => onFilterChange('certified', true)}
+              >
+                Test Certified Filter
+              </button>
+            </div>
+          );
+        },
+    );
 
     render(<DatasourceAdvancedSearchModal {...defaultProps} />);
 
@@ -241,9 +255,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('handles empty filter values', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -263,9 +276,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('handles null and undefined filter values', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -275,23 +287,34 @@ describe('DatasourceAdvancedSearchModal', () => {
     });
 
     // Mock FilterSidebar to trigger null/undefined filters
-    jest.doMock('./FilterSidebar', () => {
-      return function MockFilterSidebar({ onFilterChange }: any) {
-        return (
-          <div data-testid="filter-sidebar">
-            <button onClick={() => onFilterChange('table_name', null)}>
-              Test Null Filter
-            </button>
-            <button onClick={() => onFilterChange('table_name', undefined)}>
-              Test Undefined Filter
-            </button>
-            <button onClick={() => onFilterChange('table_name', '')}>
-              Test Empty Filter
-            </button>
-          </div>
-        );
-      };
-    });
+    jest.doMock(
+      './FilterSidebar',
+      () =>
+        function MockFilterSidebar({ onFilterChange }: any) {
+          return (
+            <div data-testid="filter-sidebar">
+              <button
+                type="button"
+                onClick={() => onFilterChange('table_name', null)}
+              >
+                Test Null Filter
+              </button>
+              <button
+                type="button"
+                onClick={() => onFilterChange('table_name', undefined)}
+              >
+                Test Undefined Filter
+              </button>
+              <button
+                type="button"
+                onClick={() => onFilterChange('table_name', '')}
+              >
+                Test Empty Filter
+              </button>
+            </div>
+          );
+        },
+    );
 
     render(<DatasourceAdvancedSearchModal {...defaultProps} />);
 
@@ -329,9 +352,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('calls fetchData with correct parameters', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -353,9 +375,8 @@ describe('DatasourceAdvancedSearchModal', () => {
   });
 
   test('handles multiple filter changes', () => {
-    const { useListViewResource } = require('src/views/CRUD/hooks');
     const mockFetchData = jest.fn();
-    useListViewResource.mockReturnValue({
+    (useListViewResource as jest.Mock).mockReturnValue({
       state: {
         loading: false,
         resourceCollection: [],
@@ -365,22 +386,25 @@ describe('DatasourceAdvancedSearchModal', () => {
     });
 
     // Mock FilterSidebar to trigger multiple filters
-    jest.doMock('./FilterSidebar', () => {
-      return function MockFilterSidebar({ onFilterChange }: any) {
-        return (
-          <div data-testid="filter-sidebar">
-            <button
-              onClick={() => {
-                onFilterChange('table_name', 'test');
-                onFilterChange('certified', true);
-              }}
-            >
-              Test Multiple Filters
-            </button>
-          </div>
-        );
-      };
-    });
+    jest.doMock(
+      './FilterSidebar',
+      () =>
+        function MockFilterSidebar({ onFilterChange }: any) {
+          return (
+            <div data-testid="filter-sidebar">
+              <button
+                type="button"
+                onClick={() => {
+                  onFilterChange('table_name', 'test');
+                  onFilterChange('certified', true);
+                }}
+              >
+                Test Multiple Filters
+              </button>
+            </div>
+          );
+        },
+    );
 
     render(<DatasourceAdvancedSearchModal {...defaultProps} />);
 

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.test.tsx
@@ -1,0 +1,408 @@
+import {
+  UserRoles,
+  UserWithPermissionsAndRoles,
+} from 'src/types/bootstrapTypes';
+import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+
+import DatasourceAdvancedSearchModal from './DatasourceAdvancedSearchModal';
+
+// Mock the hooks and utilities
+jest.mock('src/views/CRUD/hooks', () => ({
+  useListViewResource: jest.fn(() => ({
+    state: {
+      loading: false,
+      resourceCollection: [],
+      resourceCount: 0,
+    },
+    fetchData: jest.fn(),
+  })),
+}));
+
+jest.mock('src/explore/exploreUtils', () => ({
+  useDebouncedEffect: jest.fn((callback, delay, deps) => {
+    // Call the callback immediately for testing
+    callback();
+  }),
+  formatSelectOptions: jest.fn(options => options),
+}));
+
+jest.mock(
+  'src/components/MessageToasts/withToasts',
+  () => (Component: any) => Component,
+);
+
+// Mock the child components
+jest.mock('./FilterSidebar', () => {
+  return function MockFilterSidebar({ onFilterChange, onClearFilters }: any) {
+    return (
+      <div data-test="filter-sidebar">
+        <button onClick={() => onFilterChange('table_name', 'test')}>
+          Test Filter
+        </button>
+        <button onClick={() => onFilterChange('certified', true)}>
+          Test Certified Filter
+        </button>
+        <button onClick={onClearFilters}>Clear Filters</button>
+        <button
+          onClick={() => {
+            onFilterChange('table_name', 'test');
+            onFilterChange('certified', true);
+          }}
+        >
+          Test Multiple Filters
+        </button>
+      </div>
+    );
+  };
+});
+
+jest.mock('./DatasetTable', () => {
+  return function MockDatasetTable({
+    onSelectDatasource,
+    onServerPagination,
+  }: any) {
+    return (
+      <div data-test="dataset-table">
+        <button
+          onClick={() =>
+            onSelectDatasource({
+              id: 1,
+              table_name: 'test_table',
+              type: 'table',
+            })
+          }
+        >
+          Select Dataset
+        </button>
+        <button onClick={() => onServerPagination({ pageIndex: 1 })}>
+          Next Page
+        </button>
+      </div>
+    );
+  };
+});
+
+const mockUser: UserWithPermissionsAndRoles = {
+  userId: 1,
+  firstName: 'John',
+  lastName: 'Doe',
+  username: 'john.doe',
+  email: 'john.doe@example.com',
+  isActive: true,
+  createdOn: '2023-01-01T00:00:00Z',
+  isAnonymous: false,
+  roles: {} as UserRoles,
+  permissions: {},
+};
+
+const defaultProps = {
+  addDangerToast: jest.fn(),
+  addSuccessToast: jest.fn(),
+  onDatasourceSelect: jest.fn(),
+  onHide: jest.fn(),
+  show: true,
+  user: mockUser,
+};
+
+describe('DatasourceAdvancedSearchModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders without crashing when show is true', () => {
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+    expect(screen.getByText('Advanced Dataset Search')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('dataset-table')).toBeInTheDocument();
+  });
+
+  test('does not render when show is false', () => {
+    render(<DatasourceAdvancedSearchModal {...defaultProps} show={false} />);
+    expect(
+      screen.queryByText('Advanced Dataset Search'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('handles datasource selection', () => {
+    const onDatasourceSelect = jest.fn();
+    const onHide = jest.fn();
+
+    render(
+      <DatasourceAdvancedSearchModal
+        {...defaultProps}
+        onDatasourceSelect={onDatasourceSelect}
+        onHide={onHide}
+      />,
+    );
+
+    const selectButton = screen.getByText('Select Dataset');
+    fireEvent.click(selectButton);
+
+    expect(onDatasourceSelect).toHaveBeenCalledWith({
+      label: 'test_table',
+      value: '1__table',
+    });
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  test('handles filter changes', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    const filterButton = screen.getByText('Test Filter');
+    fireEvent.click(filterButton);
+
+    // The debounced effect should trigger fetchData
+    expect(mockFetchData).toHaveBeenCalled();
+  });
+
+  test('builds filter query correctly for table_name', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    // Trigger a filter change
+    const filterButton = screen.getByText('Test Filter');
+    fireEvent.click(filterButton);
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'table_name',
+            operator: 'ct',
+            value: 'test',
+          }),
+        ]),
+      }),
+    );
+  });
+
+  test('builds filter query correctly for certified filter', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    // Mock FilterSidebar to trigger certified filter
+    jest.doMock('./FilterSidebar', () => {
+      return function MockFilterSidebar({ onFilterChange }: any) {
+        return (
+          <div data-testid="filter-sidebar">
+            <button onClick={() => onFilterChange('certified', true)}>
+              Test Certified Filter
+            </button>
+          </div>
+        );
+      };
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    const certifiedButton = screen.getByText('Test Certified Filter');
+    fireEvent.click(certifiedButton);
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'id',
+            operator: 'dataset_is_certified',
+            value: true,
+          }),
+        ]),
+      }),
+    );
+  });
+
+  test('handles empty filter values', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    // The component should handle empty filters gracefully
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [],
+      }),
+    );
+  });
+
+  test('handles null and undefined filter values', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    // Mock FilterSidebar to trigger null/undefined filters
+    jest.doMock('./FilterSidebar', () => {
+      return function MockFilterSidebar({ onFilterChange }: any) {
+        return (
+          <div data-testid="filter-sidebar">
+            <button onClick={() => onFilterChange('table_name', null)}>
+              Test Null Filter
+            </button>
+            <button onClick={() => onFilterChange('table_name', undefined)}>
+              Test Undefined Filter
+            </button>
+            <button onClick={() => onFilterChange('table_name', '')}>
+              Test Empty Filter
+            </button>
+          </div>
+        );
+      };
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    // Should not include null, undefined, or empty string filters
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [],
+      }),
+    );
+  });
+
+  test('handles user with missing properties', () => {
+    const userWithMissingProps = {
+      ...mockUser,
+      userId: undefined,
+      firstName: undefined,
+      lastName: undefined,
+      username: undefined,
+    };
+
+    render(
+      <DatasourceAdvancedSearchModal
+        {...defaultProps}
+        user={userWithMissingProps}
+      />,
+    );
+    expect(screen.getByText('Advanced Dataset Search')).toBeInTheDocument();
+  });
+
+  test('handles null user', () => {
+    render(
+      <DatasourceAdvancedSearchModal {...defaultProps} user={null as any} />,
+    );
+    expect(screen.getByText('Advanced Dataset Search')).toBeInTheDocument();
+  });
+
+  test('calls fetchData with correct parameters', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageIndex: 0,
+        pageSize: 25, // DATASET_PAGE_SIZE
+        filters: [],
+        sortBy: expect.any(Array), // Just check that it's an array
+      }),
+    );
+  });
+
+  test('handles multiple filter changes', () => {
+    const { useListViewResource } = require('src/views/CRUD/hooks');
+    const mockFetchData = jest.fn();
+    useListViewResource.mockReturnValue({
+      state: {
+        loading: false,
+        resourceCollection: [],
+        resourceCount: 0,
+      },
+      fetchData: mockFetchData,
+    });
+
+    // Mock FilterSidebar to trigger multiple filters
+    jest.doMock('./FilterSidebar', () => {
+      return function MockFilterSidebar({ onFilterChange }: any) {
+        return (
+          <div data-testid="filter-sidebar">
+            <button
+              onClick={() => {
+                onFilterChange('table_name', 'test');
+                onFilterChange('certified', true);
+              }}
+            >
+              Test Multiple Filters
+            </button>
+          </div>
+        );
+      };
+    });
+
+    render(<DatasourceAdvancedSearchModal {...defaultProps} />);
+
+    const multiFilterButton = screen.getByText('Test Multiple Filters');
+    fireEvent.click(multiFilterButton);
+
+    // Should handle multiple filters correctly
+    expect(mockFetchData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            id: 'table_name',
+            operator: 'ct',
+            value: 'test',
+          }),
+          expect.objectContaining({
+            id: 'id',
+            operator: 'dataset_is_certified',
+            value: true,
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
@@ -2,20 +2,21 @@ import {
   PAGE_SIZE as DATASET_PAGE_SIZE,
   SORT_BY as DATASET_SORT_BY,
 } from 'src/features/datasets/constants';
-import React, { FunctionComponent, useCallback, useRef, useState } from 'react';
+import { FunctionComponent, useCallback, useRef, useState } from 'react';
 import { ServerPagination, SortByType } from 'src/components/TableView/types';
 import { styled, t } from '@superset-ui/core';
 
 import { Dataset } from '@superset-ui/chart-controls';
-import DatasetTable from './DatasetTable';
 import { FilterOperator } from 'src/components/ListView/types';
-import FilterSidebar from './FilterSidebar';
 import Modal from 'src/components/Modal';
 import { SLOW_DEBOUNCE } from 'src/constants';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { useDebouncedEffect } from 'src/explore/exploreUtils';
 import { useListViewResource } from 'src/views/CRUD/hooks';
 import withToasts from 'src/components/MessageToasts/withToasts';
+
+import DatasetTable from './DatasetTable';
+import FilterSidebar from './FilterSidebar';
 
 const StyledModal = styled(Modal)`
   .ant-modal-body {
@@ -89,9 +90,7 @@ const DatasourceAdvancedSearchModal: FunctionComponent<
 
     // Clear all filter components
     Object.values(filterRefs.current).forEach(ref => {
-      if (ref && ref.clearFilter) {
-        ref.clearFilter();
-      }
+      ref?.clearFilter?.();
     });
   }, []);
 
@@ -107,6 +106,8 @@ const DatasourceAdvancedSearchModal: FunctionComponent<
       return null;
     }
     const operator = OPERATOR_BY_FILTER_KEY[filterKey];
+    // Certified filter is temporarily removed in this implementation
+    // but leaving this logic for when (if) it is implemented
     const filterId =
       operator !== FilterOperator.DatasetIsCertified ? filterKey : 'id';
     return {

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
@@ -1,0 +1,181 @@
+import {
+  PAGE_SIZE as DATASET_PAGE_SIZE,
+  SORT_BY as DATASET_SORT_BY,
+} from 'src/features/datasets/constants';
+import React, { FunctionComponent, useCallback, useRef, useState } from 'react';
+import { ServerPagination, SortByType } from 'src/components/TableView/types';
+import { styled, t } from '@superset-ui/core';
+
+import { Dataset } from '@superset-ui/chart-controls';
+import DatasetTable from './DatasetTable';
+import { FilterOperator } from 'src/components/ListView/types';
+import FilterSidebar from './FilterSidebar';
+import Modal from 'src/components/Modal';
+import { SLOW_DEBOUNCE } from 'src/constants';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { useDebouncedEffect } from 'src/explore/exploreUtils';
+import { useListViewResource } from 'src/views/CRUD/hooks';
+import withToasts from 'src/components/MessageToasts/withToasts';
+
+const StyledModal = styled(Modal)`
+  .ant-modal-body {
+    display: flex;
+    flex-direction: row;
+    padding: 0;
+  }
+`;
+
+const OPERATOR_BY_FILTER_KEY: Record<string, string> = {
+  table_name: FilterOperator.Contains,
+  sql: FilterOperator.DatasetIsNullOrEmpty,
+  database: FilterOperator.RelationOneMany,
+  schema: FilterOperator.Equals,
+  owners: FilterOperator.RelationManyMany,
+  certified: FilterOperator.DatasetIsCertified,
+  changed_by: FilterOperator.RelationOneMany,
+};
+
+export interface DatasourceAdvancedSearchModalProps {
+  addDangerToast: (msg: string) => void;
+  onDatasourceSelect: (datasource: { label: string; value: string }) => void;
+  onHide: () => void;
+  show: boolean;
+  user: UserWithPermissionsAndRoles;
+}
+
+const DatasourceAdvancedSearchModal: FunctionComponent<
+  DatasourceAdvancedSearchModalProps
+> = ({ addDangerToast, onDatasourceSelect, onHide, show, user }) => {
+  // State
+  const [pageIndex, setPageIndex] = useState<number>(0);
+  const [sortBy, setSortBy] = useState<SortByType>(DATASET_SORT_BY);
+  const [appliedFilters, setAppliedFilters] = useState<{ [key: string]: any }>(
+    {},
+  );
+
+  // Refs
+  const filterRefs = useRef<{ [key: string]: any }>({});
+
+  // Data fetching
+  const {
+    state: { loading, resourceCollection, resourceCount },
+    fetchData,
+  } = useListViewResource<Dataset>('dataset', t('dataset'), addDangerToast);
+
+  // Event Handlers
+  const handleDatasourceSelect = useCallback(
+    (datasource: any) => {
+      const formattedDatasource = {
+        label: datasource.table_name,
+        value: `${datasource.id}__${datasource.type}`,
+      };
+      onDatasourceSelect(formattedDatasource);
+      onHide();
+    },
+    [onDatasourceSelect, onHide],
+  );
+
+  const handleFilterChange = useCallback((filterKey: string, value: any) => {
+    setAppliedFilters((prev: any) => ({
+      ...prev,
+      [filterKey]: value,
+    }));
+    setPageIndex(0);
+  }, []);
+
+  const handleClearFilters = useCallback(() => {
+    setAppliedFilters({});
+    setPageIndex(0);
+
+    // Clear all filter components
+    Object.values(filterRefs.current).forEach(ref => {
+      if (ref && ref.clearFilter) {
+        ref.clearFilter();
+      }
+    });
+  }, []);
+
+  const handleServerPagination = useCallback((args: ServerPagination) => {
+    setPageIndex(args.pageIndex);
+    if (args.sortBy) {
+      setSortBy(args.sortBy.length > 0 ? args.sortBy : DATASET_SORT_BY);
+    }
+  }, []);
+
+  const buildFilterQuery = (filterKey: string, value: any) => {
+    if (!(filterKey in OPERATOR_BY_FILTER_KEY)) {
+      return null;
+    }
+    const operator = OPERATOR_BY_FILTER_KEY[filterKey];
+    const filterId =
+      operator !== FilterOperator.DatasetIsCertified ? filterKey : 'id';
+    return {
+      id: filterId,
+      operator,
+      value,
+    };
+  };
+
+  const buildFiltersArray = useCallback(
+    (appliedFilters: Record<string, any>) => {
+      const filters: any[] = [];
+
+      Object.entries(appliedFilters).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== '') {
+          const filter = buildFilterQuery(key, value);
+          if (filter) {
+            filters.push(filter);
+          }
+        }
+      });
+
+      return filters;
+    },
+    [],
+  );
+
+  // Data fetching effect
+  useDebouncedEffect(
+    () => {
+      const filters = buildFiltersArray(appliedFilters);
+      fetchData({
+        pageIndex,
+        pageSize: DATASET_PAGE_SIZE,
+        filters,
+        sortBy,
+      });
+    },
+    SLOW_DEBOUNCE,
+    [pageIndex, sortBy, appliedFilters],
+  );
+
+  return (
+    <StyledModal
+      show={show}
+      onHide={onHide}
+      responsive
+      title={t('Advanced Dataset Search')}
+      hideFooter
+    >
+      <FilterSidebar
+        user={user}
+        appliedFilters={appliedFilters}
+        onFilterChange={handleFilterChange}
+        onClearFilters={handleClearFilters}
+        filterRefs={filterRefs}
+      />
+      <DatasetTable
+        loading={loading}
+        data={resourceCollection}
+        pageSize={DATASET_PAGE_SIZE}
+        pageIndex={pageIndex}
+        sortBy={sortBy}
+        totalCount={resourceCount}
+        onSelectDatasource={handleDatasourceSelect}
+        onServerPagination={handleServerPagination}
+      />
+    </StyledModal>
+  );
+};
+
+export default withToasts(DatasourceAdvancedSearchModal);

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.test.tsx
@@ -1,0 +1,189 @@
+import {
+  UserRoles,
+  UserWithPermissionsAndRoles,
+} from 'src/types/bootstrapTypes';
+import { fireEvent, render, screen } from 'spec/helpers/testing-library';
+
+import FilterSidebar from './FilterSidebar';
+import userEvent from '@testing-library/user-event';
+
+// Mock the CRUD utils
+jest.mock('src/views/CRUD/utils', () => ({
+  createErrorHandler: jest.fn(() => jest.fn()),
+  createFetchDistinct: jest.fn(() => jest.fn()),
+  createFetchRelated: jest.fn(() => jest.fn()),
+}));
+
+const mockUser: UserWithPermissionsAndRoles = {
+  userId: 1,
+  firstName: 'John',
+  lastName: 'Doe',
+  username: 'john.doe',
+  email: 'john.doe@example.com',
+  isActive: true,
+  createdOn: '2023-01-01T00:00:00Z',
+  isAnonymous: false,
+  roles: {} as UserRoles,
+  permissions: {},
+};
+
+const defaultProps = {
+  user: mockUser,
+  appliedFilters: {},
+  onFilterChange: jest.fn(),
+  onClearFilters: jest.fn(),
+  filterRefs: { current: {} },
+};
+
+describe('FilterSidebar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders without crashing', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Certified')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Schema')).toBeInTheDocument();
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.getByText('Database')).toBeInTheDocument();
+    expect(screen.getByText('Modified by')).toBeInTheDocument();
+  });
+
+  test('renders clear filters button', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Clear Filters')).toBeInTheDocument();
+  });
+
+  test('renders name filter with custom search input', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    expect(nameInput).toBeInTheDocument();
+    expect(nameInput).toHaveAttribute('name', 'table_name');
+  });
+
+  test('handles name filter input changes', async () => {
+    const onFilterChange = jest.fn();
+    render(<FilterSidebar {...defaultProps} onFilterChange={onFilterChange} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    await userEvent.type(nameInput, 'test dataset');
+
+    expect(onFilterChange).toHaveBeenCalledWith('table_name', 'test dataset');
+  });
+
+  test('clears name filter when input is cleared', async () => {
+    const onFilterChange = jest.fn();
+    render(<FilterSidebar {...defaultProps} onFilterChange={onFilterChange} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    await userEvent.type(nameInput, 'test');
+    await userEvent.clear(nameInput);
+
+    expect(onFilterChange).toHaveBeenCalledWith('table_name', '');
+  });
+
+  test('initializes name filter with applied filter value', () => {
+    const appliedFilters = { table_name: 'initial value' };
+    render(<FilterSidebar {...defaultProps} appliedFilters={appliedFilters} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    expect(nameInput).toHaveValue('initial value');
+  });
+
+  test('handles clear filters button click', () => {
+    const onClearFilters = jest.fn();
+    render(<FilterSidebar {...defaultProps} onClearFilters={onClearFilters} />);
+
+    const clearButton = screen.getByText('Clear Filters');
+    fireEvent.click(clearButton);
+
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders owner filter', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+  });
+
+  test('renders schema filter', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Schema')).toBeInTheDocument();
+  });
+
+  test('renders type filter with correct options', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Type')).toBeInTheDocument();
+  });
+
+  test('renders database filter', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Database')).toBeInTheDocument();
+  });
+
+  test('renders modified by filter', () => {
+    render(<FilterSidebar {...defaultProps} />);
+    expect(screen.getByText('Modified by')).toBeInTheDocument();
+  });
+
+  test('handles null user', () => {
+    render(<FilterSidebar {...defaultProps} user={null as any} />);
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  test('updates name filter when appliedFilters change', () => {
+    const { rerender } = render(<FilterSidebar {...defaultProps} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    expect(nameInput).toHaveValue('');
+
+    // Update appliedFilters and rerender
+    rerender(
+      <FilterSidebar
+        {...defaultProps}
+        appliedFilters={{ table_name: 'new value' }}
+      />,
+    );
+
+    // The input should now have the new value
+    expect(nameInput).toHaveValue('new value');
+  });
+
+  test('maintains filter refs', () => {
+    const filterRefs = { current: {} };
+    render(<FilterSidebar {...defaultProps} filterRefs={filterRefs} />);
+
+    // The component should populate the filterRefs
+    expect(filterRefs.current).toBeDefined();
+  });
+
+  test('handles rapid typing in name filter', async () => {
+    const onFilterChange = jest.fn();
+    render(<FilterSidebar {...defaultProps} onFilterChange={onFilterChange} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+
+    // Type rapidly
+    await userEvent.type(nameInput, 'a');
+    await userEvent.type(nameInput, 'b');
+    await userEvent.type(nameInput, 'c');
+
+    // Should have been called for each character
+    expect(onFilterChange).toHaveBeenCalledTimes(3);
+    expect(onFilterChange).toHaveBeenCalledWith('table_name', 'a');
+    expect(onFilterChange).toHaveBeenCalledWith('table_name', 'ab');
+    expect(onFilterChange).toHaveBeenCalledWith('table_name', 'abc');
+  });
+
+  test('handles empty string in name filter', async () => {
+    const onFilterChange = jest.fn();
+    render(<FilterSidebar {...defaultProps} onFilterChange={onFilterChange} />);
+
+    const nameInput = screen.getByPlaceholderText('Type a value');
+    await userEvent.type(nameInput, 'test');
+    await userEvent.clear(nameInput);
+
+    expect(onFilterChange).toHaveBeenLastCalledWith('table_name', '');
+  });
+});

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.test.tsx
@@ -4,8 +4,9 @@ import {
 } from 'src/types/bootstrapTypes';
 import { fireEvent, render, screen } from 'spec/helpers/testing-library';
 
-import FilterSidebar from './FilterSidebar';
 import userEvent from '@testing-library/user-event';
+
+import FilterSidebar from './FilterSidebar';
 
 // Mock the CRUD utils
 jest.mock('src/views/CRUD/utils', () => ({
@@ -43,7 +44,8 @@ describe('FilterSidebar', () => {
   test('renders without crashing', () => {
     render(<FilterSidebar {...defaultProps} />);
     expect(screen.getByText('Name')).toBeInTheDocument();
-    expect(screen.getByText('Certified')).toBeInTheDocument();
+    // TODO: Add back in when certified filter is implemented
+    // expect(screen.getByText('Certified')).toBeInTheDocument();
     expect(screen.getByText('Owner')).toBeInTheDocument();
     expect(screen.getByText('Schema')).toBeInTheDocument();
     expect(screen.getByText('Type')).toBeInTheDocument();
@@ -100,31 +102,6 @@ describe('FilterSidebar', () => {
     fireEvent.click(clearButton);
 
     expect(onClearFilters).toHaveBeenCalledTimes(1);
-  });
-
-  test('renders owner filter', () => {
-    render(<FilterSidebar {...defaultProps} />);
-    expect(screen.getByText('Owner')).toBeInTheDocument();
-  });
-
-  test('renders schema filter', () => {
-    render(<FilterSidebar {...defaultProps} />);
-    expect(screen.getByText('Schema')).toBeInTheDocument();
-  });
-
-  test('renders type filter with correct options', () => {
-    render(<FilterSidebar {...defaultProps} />);
-    expect(screen.getByText('Type')).toBeInTheDocument();
-  });
-
-  test('renders database filter', () => {
-    render(<FilterSidebar {...defaultProps} />);
-    expect(screen.getByText('Database')).toBeInTheDocument();
-  });
-
-  test('renders modified by filter', () => {
-    render(<FilterSidebar {...defaultProps} />);
-    expect(screen.getByText('Modified by')).toBeInTheDocument();
   });
 
   test('handles null user', () => {

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.tsx
@@ -1,11 +1,11 @@
 import { FilterOperator, Filters } from 'src/components/ListView';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createErrorHandler,
   createFetchDistinct,
   createFetchRelated,
 } from 'src/views/CRUD/utils';
 import { styled, t } from '@superset-ui/core';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { AntdInput } from 'src/components';
 import Button from 'src/components/Button';
@@ -44,19 +44,6 @@ const createFilterDefinitions = (user: any): Filters => [
     input: 'search',
     operator: FilterOperator.Contains,
     unfilteredLabel: t('All'),
-  },
-  {
-    Header: t('Certified'),
-    key: 'certified',
-    id: 'certified',
-    urlDisplay: 'certified',
-    input: 'select',
-    operator: FilterOperator.DatasetIsCertified,
-    unfilteredLabel: t('Any'),
-    selects: [
-      { label: t('Yes'), value: true },
-      { label: t('No'), value: false },
-    ],
   },
   {
     Header: t('Owner'),
@@ -206,6 +193,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
         name: filterType.id,
         initialValue: appliedFilters[filterType.id],
         ref: (ref: any) => {
+          // eslint-disable-next-line no-param-reassign
           filterRefs.current[filterType.id] = ref;
         },
       };
@@ -223,7 +211,7 @@ const FilterSidebar: React.FC<FilterSidebarProps> = ({
                 name={filterType.id}
                 value={searchValue}
                 onChange={e => handleSearchChange(e.target.value)}
-                prefix={<SearchIcon size="l" />}
+                prefix={<SearchIcon iconSize="l" />}
               />
             </FilterSection>
           );

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/FilterSidebar.tsx
@@ -1,0 +1,292 @@
+import { FilterOperator, Filters } from 'src/components/ListView';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createErrorHandler,
+  createFetchDistinct,
+  createFetchRelated,
+} from 'src/views/CRUD/utils';
+import { styled, t } from '@superset-ui/core';
+
+import { AntdInput } from 'src/components';
+import Button from 'src/components/Button';
+import { FormLabel } from 'src/components/Form';
+import Icons from 'src/components/Icons';
+import SearchFilter from 'src/components/ListView/Filters/Search';
+import SelectFilter from 'src/components/ListView/Filters/Select';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+
+const SIDEBAR_WIDTH = '250px';
+
+const SearchIcon = styled(Icons.Search)`
+  color: ${({ theme }) => theme.colors.grayscale.light1};
+`;
+
+const StyledInput = styled(AntdInput)`
+  border-radius: ${({ theme }) => theme.gridUnit}px;
+`;
+
+const createUserForFilters = (user: UserWithPermissionsAndRoles) => {
+  if (!user) return undefined;
+
+  return {
+    userId: user.userId || 0,
+    firstName: user.firstName || '',
+    lastName: user.lastName || '',
+    username: user.username || '',
+  };
+};
+
+const createFilterDefinitions = (user: any): Filters => [
+  {
+    Header: t('Name'),
+    key: 'table_name',
+    id: 'table_name',
+    input: 'search',
+    operator: FilterOperator.Contains,
+    unfilteredLabel: t('All'),
+  },
+  {
+    Header: t('Certified'),
+    key: 'certified',
+    id: 'certified',
+    urlDisplay: 'certified',
+    input: 'select',
+    operator: FilterOperator.DatasetIsCertified,
+    unfilteredLabel: t('Any'),
+    selects: [
+      { label: t('Yes'), value: true },
+      { label: t('No'), value: false },
+    ],
+  },
+  {
+    Header: t('Owner'),
+    key: 'owner',
+    id: 'owners',
+    input: 'select',
+    operator: FilterOperator.RelationManyMany,
+    unfilteredLabel: 'All',
+    fetchSelects: createFetchRelated(
+      'dataset',
+      'owners',
+      createErrorHandler(errMsg =>
+        t('An error occurred while fetching dataset owner values: %s', errMsg),
+      ),
+      createUserForFilters(user),
+    ),
+    paginate: true,
+  },
+  {
+    Header: t('Schema'),
+    key: 'schema',
+    id: 'schema',
+    input: 'select',
+    operator: FilterOperator.Equals,
+    unfilteredLabel: 'All',
+    fetchSelects: createFetchDistinct(
+      'dataset',
+      'schema',
+      createErrorHandler(errMsg =>
+        t('An error occurred while fetching schema values: %s', errMsg),
+      ),
+    ),
+    paginate: true,
+  },
+  {
+    Header: t('Type'),
+    key: 'sql',
+    id: 'sql',
+    input: 'select',
+    operator: FilterOperator.DatasetIsNullOrEmpty,
+    unfilteredLabel: 'All',
+    selects: [
+      { label: t('Virtual'), value: false },
+      { label: t('Physical'), value: true },
+    ],
+  },
+  {
+    Header: t('Database'),
+    key: 'database',
+    id: 'database',
+    input: 'select',
+    operator: FilterOperator.RelationOneMany,
+    unfilteredLabel: 'All',
+    fetchSelects: createFetchRelated(
+      'dataset',
+      'database',
+      createErrorHandler(errMsg =>
+        t('An error occurred while fetching datasets: %s', errMsg),
+      ),
+    ),
+    paginate: true,
+  },
+  {
+    Header: t('Modified by'),
+    key: 'changed_by',
+    id: 'changed_by',
+    input: 'select',
+    operator: FilterOperator.RelationOneMany,
+    unfilteredLabel: t('All'),
+    fetchSelects: createFetchRelated(
+      'dataset',
+      'changed_by',
+      createErrorHandler(errMsg =>
+        t(
+          'An error occurred while fetching dataset datasource values: %s',
+          errMsg,
+        ),
+      ),
+      createUserForFilters(user),
+    ),
+    paginate: true,
+  },
+];
+
+export const FilterSection = styled.div`
+  margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
+`;
+
+const Sidebar = styled.div`
+  width: ${SIDEBAR_WIDTH};
+  border-right: 1px solid ${({ theme }) => theme.colors.grayscale.light2};
+  padding: ${({ theme }) => theme.gridUnit * 5}px;
+  overflow-y: auto;
+  flex-shrink: 0;
+`;
+
+interface FilterSidebarProps {
+  user: UserWithPermissionsAndRoles;
+  appliedFilters: {
+    [key: string]: any;
+  };
+  onFilterChange: (filterKey: string, value: any) => void;
+  onClearFilters: () => void;
+  filterRefs: React.MutableRefObject<{ [key: string]: any }>;
+}
+
+const FilterSidebar: React.FC<FilterSidebarProps> = ({
+  user,
+  appliedFilters,
+  onFilterChange,
+  onClearFilters,
+  filterRefs,
+}) => {
+  // State for search input
+  const [searchValue, setSearchValue] = useState(
+    appliedFilters.table_name || '',
+  );
+
+  // Update search value when appliedFilters change
+  useEffect(() => {
+    setSearchValue(appliedFilters.table_name || '');
+  }, [appliedFilters.table_name]);
+
+  // Create filter definitions internally
+  const filterDefinitions = useMemo(
+    () => createFilterDefinitions(user),
+    [user],
+  );
+
+  // Handle search input change
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+      onFilterChange('table_name', value);
+    },
+    [onFilterChange],
+  );
+
+  const renderFilterComponent = useCallback(
+    (filterType: any) => {
+      const commonProps = {
+        key: filterType.id,
+        Header:
+          typeof filterType.Header === 'string'
+            ? filterType.Header
+            : filterType.id,
+        name: filterType.id,
+        initialValue: appliedFilters[filterType.id],
+        ref: (ref: any) => {
+          filterRefs.current[filterType.id] = ref;
+        },
+      };
+
+      if (filterType.input === 'search') {
+        // Special handling for name filter to enable real-time search
+        if (filterType.id === 'table_name') {
+          return (
+            <FilterSection key={filterType.id}>
+              <FormLabel>{filterType.Header}</FormLabel>
+              <StyledInput
+                allowClear
+                data-test="filters-search"
+                placeholder={t('Type a value')}
+                name={filterType.id}
+                value={searchValue}
+                onChange={e => handleSearchChange(e.target.value)}
+                prefix={<SearchIcon size="l" />}
+              />
+            </FilterSection>
+          );
+        }
+
+        // Default search filter for other fields
+        return (
+          <FilterSection key={filterType.id}>
+            <SearchFilter
+              {...commonProps}
+              toolTipDescription={filterType.toolTipDescription}
+              onSubmit={(value: string) => onFilterChange(filterType.id, value)}
+            />
+          </FilterSection>
+        );
+      }
+
+      if (filterType.input === 'select') {
+        return (
+          <FilterSection key={filterType.id}>
+            <SelectFilter
+              {...commonProps}
+              selects={filterType.selects}
+              fetchSelects={filterType.fetchSelects}
+              paginate={filterType.paginate}
+              onSelect={(selected: any) =>
+                onFilterChange(filterType.id, selected?.value)
+              }
+            />
+          </FilterSection>
+        );
+      }
+
+      return null;
+    },
+    [
+      appliedFilters,
+      onFilterChange,
+      filterRefs,
+      searchValue,
+      handleSearchChange,
+    ],
+  );
+
+  return (
+    <Sidebar>
+      <FilterSection>
+        <div style={{ marginBottom: '16px' }}>
+          {filterDefinitions.map(renderFilterComponent)}
+        </div>
+        <Button
+          onClick={() => {
+            onClearFilters();
+            setSearchValue('');
+          }}
+          buttonStyle="secondary"
+          block
+        >
+          {t('Clear Filters')}
+        </Button>
+      </FilterSection>
+    </Sidebar>
+  );
+};
+
+export default FilterSidebar;

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/index.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './DatasourceAdvancedSearchModal';

--- a/superset-frontend/src/explore/components/ChartPills.tsx
+++ b/superset-frontend/src/explore/components/ChartPills.tsx
@@ -22,6 +22,8 @@ import RowCountLabel from 'src/explore/components/RowCountLabel';
 import CachedLabel from 'src/components/CachedLabel';
 import Timer from 'src/components/Timer';
 import { Type } from 'src/components/Label';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
 import { getPinterestChartPills } from '@pinterest-plugins/src/explore/components/pinterestChartPills';
 
 const CHART_STATUS_MAP = {

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -24,11 +24,20 @@ import { createMemoryHistory } from 'history';
 import { ChartCreation } from 'src/pages/ChartCreation';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 
+import { Provider } from 'react-redux';
+import React from 'react';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
 jest.mock('src/components/DynamicPlugins', () => ({
   usePluginContext: () => ({
     mountedPluginMetadata: { table: { name: 'Table', tags: [] } },
   }),
 }));
+
+// Mock store for withToasts
+const mockStore = configureStore([thunk]);
+const store = mockStore({});
 
 const mockDatasourceResponse = {
   result: [
@@ -81,6 +90,7 @@ const routeProps = {
   history,
   location: {} as any,
   match: {} as any,
+  addDangerToast: jest.fn(),
 };
 
 const renderOptions = {
@@ -89,7 +99,9 @@ const renderOptions = {
 
 async function renderComponent(user = mockUser) {
   render(
-    <ChartCreation user={user} addSuccessToast={() => null} {...routeProps} />,
+    <Provider store={store}>
+      <ChartCreation user={user} addSuccessToast={() => null} {...routeProps} />
+    </Provider>,
     renderOptions,
   );
   await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));

--- a/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
+++ b/superset-frontend/src/pages/ChartCreation/ChartCreation.test.tsx
@@ -17,17 +17,16 @@
  * under the License.
  */
 
-import userEvent from '@testing-library/user-event';
-import { screen, waitFor, render } from 'spec/helpers/testing-library';
-import fetchMock from 'fetch-mock';
-import { createMemoryHistory } from 'history';
-import { ChartCreation } from 'src/pages/ChartCreation';
-import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
 
+import { ChartCreation } from 'src/pages/ChartCreation';
 import { Provider } from 'react-redux';
-import React from 'react';
+import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import configureStore from 'redux-mock-store';
+import { createMemoryHistory } from 'history';
+import fetchMock from 'fetch-mock';
 import thunk from 'redux-thunk';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('src/components/DynamicPlugins', () => ({
   usePluginContext: () => ({

--- a/superset-frontend/src/pages/ChartCreation/index.tsx
+++ b/superset-frontend/src/pages/ChartCreation/index.tsx
@@ -43,10 +43,12 @@ import {
   Dataset,
   DatasetSelectLabel,
 } from 'src/features/datasets/DatasetSelectLabel';
+import DatasourceAdvancedSearchModal from 'src/components/Datasource/DatasourceAdvancedSearchModal';
 
 export interface ChartCreationProps extends RouteComponentProps {
   user: UserWithPermissionsAndRoles;
   addSuccessToast: (arg: string) => void;
+  addDangerToast: (arg: string) => void;
 }
 
 export type ChartCreationState = {
@@ -54,6 +56,7 @@ export type ChartCreationState = {
   datasetName?: string | string[] | null;
   vizType: string | null;
   canCreateDataset: boolean;
+  showAdvancedSearch: boolean;
 };
 
 const ESTIMATED_NAV_HEIGHT = 56;
@@ -90,15 +93,22 @@ const StyledContainer = styled.div`
       flex-direction: row;
       align-items: center;
       margin-bottom: ${theme.gridUnit * 5}px;
+      gap: ${theme.gridUnit * 2}px;
 
-      & > div {
+      & .dataset-select {
+        flex: 1;
         min-width: 200px;
-        width: 300px;
       }
 
-      & > span {
+      & .dataset-actions {
+        display: flex;
+        align-items: center;
+        gap: ${theme.gridUnit * 2}px;
+        flex-shrink: 0;
+      }
+
+      & .help-text {
         color: ${theme.colors.grayscale.light1};
-        margin-left: ${theme.gridUnit * 4}px;
       }
     }
 
@@ -198,6 +208,7 @@ export class ChartCreation extends PureComponent<
         'Dataset',
         props.user.roles,
       ),
+      showAdvancedSearch: false,
     };
 
     this.changeDatasource = this.changeDatasource.bind(this);
@@ -205,6 +216,10 @@ export class ChartCreation extends PureComponent<
     this.gotoSlice = this.gotoSlice.bind(this);
     this.loadDatasources = this.loadDatasources.bind(this);
     this.onVizTypeDoubleClick = this.onVizTypeDoubleClick.bind(this);
+    this.openAdvancedSearch = this.openAdvancedSearch.bind(this);
+    this.closeAdvancedSearch = this.closeAdvancedSearch.bind(this);
+    this.handleAdvancedSearchSelect =
+      this.handleAdvancedSearchSelect.bind(this);
   }
 
   componentDidMount() {
@@ -251,6 +266,18 @@ export class ChartCreation extends PureComponent<
     if (!this.isBtnDisabled()) {
       this.gotoSlice();
     }
+  }
+
+  openAdvancedSearch() {
+    this.setState({ showAdvancedSearch: true });
+  }
+
+  closeAdvancedSearch() {
+    this.setState({ showAdvancedSearch: false });
+  }
+
+  handleAdvancedSearchSelect(datasource: { label: string; value: string }) {
+    this.setState({ datasource });
   }
 
   loadDatasources(search: string, page: number, pageSize: number) {
@@ -332,18 +359,28 @@ export class ChartCreation extends PureComponent<
             status={this.state.datasource?.value ? 'finish' : 'process'}
             description={
               <StyledStepDescription className="dataset">
-                <AsyncSelect
-                  autoFocus
-                  ariaLabel={t('Dataset')}
-                  name="select-datasource"
-                  onChange={this.changeDatasource}
-                  options={this.loadDatasources}
-                  optionFilterProps={['id', 'label']}
-                  placeholder={t('Choose a dataset')}
-                  showSearch
-                  value={this.state.datasource}
-                />
-                {datasetHelpText}
+                <div className="dataset-select">
+                  <AsyncSelect
+                    autoFocus
+                    ariaLabel={t('Dataset')}
+                    name="select-datasource"
+                    onChange={this.changeDatasource}
+                    options={this.loadDatasources}
+                    optionFilterProps={['id', 'label']}
+                    placeholder={t('Choose a dataset')}
+                    showSearch
+                    value={this.state.datasource}
+                  />
+                </div>
+                <div className="dataset-actions">
+                  <Button
+                    buttonStyle="secondary"
+                    onClick={this.openAdvancedSearch}
+                  >
+                    {t('Advanced Search')}
+                  </Button>
+                  <span className="help-text">{datasetHelpText}</span>
+                </div>
               </StyledStepDescription>
             }
           />
@@ -377,6 +414,14 @@ export class ChartCreation extends PureComponent<
             {t('Create new chart')}
           </Button>
         </div>
+        <DatasourceAdvancedSearchModal
+          show={this.state.showAdvancedSearch}
+          onHide={this.closeAdvancedSearch}
+          onDatasourceSelect={this.handleAdvancedSearchSelect}
+          user={this.props.user}
+          addSuccessToast={this.props.addSuccessToast}
+          addDangerToast={this.props.addDangerToast}
+        />
       </StyledContainer>
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Dataset selection in the chart creation page is a simple dropdown. However systems with numerous dbs, schemas, etc required a more fine grained search page to select a dataset & create a chart
- Implement an "Advanced Search" button next to dataset's dropdown in chart creation page
- When "Advanced Search" button is clicked, a modal is shown to allow the users to filter by "Schema", "owners", "database", "name", "type", "modified by".
- Once a dataset is selected from the modal, the modal will be closed, and the dataset will be updated in the chart creation page.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="2120" height="1640" alt="Screenshot 2025-10-16 at 11 56 13 PM" src="https://github.com/user-attachments/assets/98083eca-97d3-4115-9ff2-37ee3c92a9aa" />
<img width="2132" height="1644" alt="Screenshot 2025-10-16 at 11 56 23 PM" src="https://github.com/user-attachments/assets/3c7a3b16-e520-4ef9-9fd3-af1cfdc38230" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
`npm test -- --testPathPattern="DatasourceAdvancedSearchModal"`

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
