### PR TITLE
fix: Make a copy of column before parsing

### DIFF
--- a/superset/models/helpers.py
+++ b/superset/models/helpers.py
@@ -1649,13 +1649,16 @@ class ExploreMixin:  # pylint: disable=too-many-public-methods
             if isinstance(col, dict):
                 col = cast(AdhocMetric, col)
                 if col.get("sqlExpression"):
-                    col["sqlExpression"] = self._process_sql_expression(
+                    # Create a copy to avoid modifying the original query object
+                    col_copy = col.copy()
+                    col_copy["sqlExpression"] = self._process_sql_expression(
                         expression=col["sqlExpression"],
                         database_id=self.database_id,
                         engine=self.database.backend,
                         schema=self.schema,
                         template_processor=template_processor,
                     )
+                    col = col_copy
                 if utils.is_adhoc_metric(col):
                     # add adhoc sort by column to columns_by_name if not exists
                     col = self.adhoc_metric_to_sqla(col, columns_by_name)


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is an unexpected error that occurs when GLOBAL_ASYNC_QUERIES is enabled. The asynchronous task to load the chart data uses a different query_object than the api endpoint used to load the results. This is because some of the logic to generate the sql query incorrectly modifies the query_object while processing the sql expression. This causes a cache miss when loading the chart's data. In this PR we are creating a copy of the column before processing to ensure the original object isn't modified.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Reproduce by creating a metric in the chart (with a custom sql expression) with a newline at the end of the metric's sql definition. When the chart is loaded from a dashboard with GLOBAL_ASYNC_QUERIES enabled, the UI will show an "Unexpected error"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
