### PR TITLE
fix(roles): Check for user permissions when accessing dashboard via permalink

### DIFF
--- a/superset/commands/dashboard/permalink/get.py
+++ b/superset/commands/dashboard/permalink/get.py
@@ -19,7 +19,11 @@ from typing import Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
-from superset.commands.dashboard.exceptions import DashboardNotFoundError
+from superset.commands.dashboard.exceptions import (
+    DashboardAccessDeniedError,
+    DashboardNotFoundError,
+)
+from superset.exceptions import SupersetSecurityException
 from superset.commands.dashboard.permalink.base import BaseDashboardPermalinkCommand
 from superset.daos.dashboard import DashboardDAO
 from superset.daos.key_value import KeyValueDAO
@@ -45,9 +49,12 @@ class GetDashboardPermalinkCommand(BaseDashboardPermalinkCommand):
             key = decode_permalink_id(self.key, salt=self.salt)
             value = KeyValueDAO.get_value(self.resource, key, self.codec)
             if value:
-                DashboardDAO.get_by_id_or_slug(value["dashboardId"])
+                dashboard = DashboardDAO.get_by_id_or_slug(value["dashboardId"])
+                dashboard.raise_for_access()
                 return value
             return None
+        except SupersetSecurityException as ex:
+            raise DashboardAccessDeniedError() from ex
         except (
             DashboardNotFoundError,
             KeyValueCodecDecodeException,

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -869,7 +869,6 @@ class Superset(BaseSupersetView):
             standalone_mode=ReservedUrlParameters.is_standalone_mode(),
         )
 
-    @has_access
     @expose("/dashboard/p/<key>/", methods=("GET",))
     def dashboard_permalink(
         self,

--- a/tests/integration_tests/security_tests.py
+++ b/tests/integration_tests/security_tests.py
@@ -1550,6 +1550,7 @@ class TestRolePermission(SupersetTestCase):
             ["Superset", "log"],
             ["Superset", "theme"],
             ["Superset", "welcome"],
+            ["Superset", "dashboard_permalink"],
             ["SecurityApi", "login"],
             ["SecurityApi", "refresh"],
             ["SupersetIndexView", "index"],


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY

* Adds RBAC checks to the dashboard permalink access path so that users who open a dashboard via a permalink will have the same permission enforcement as when they open the dashboard through the normal UI.
* Prevents users without required view/access permissions from viewing dashboards (or components) just by using a permalink.

### TESTING INSTRUCTIONS
* Can access dashboard via permalink when not an owner/admin with matching role
* Cannot access dashboard via permalink when not an owner/admin without matching role

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
