### PR TITLE
fix(reports): Handle rate limiting in Slack notifications

### DIFF
--- a/superset/commands/report/execute.py
+++ b/superset/commands/report/execute.py
@@ -134,21 +134,26 @@ class BaseReportState:
         try:
             for recipient in self._report_schedule.recipients:
                 if recipient.type == ReportRecipientType.SLACK:
-                    recipient.type = ReportRecipientType.SLACKV2
                     slack_recipients = json.loads(recipient.recipient_config_json)
+                    new_target = get_channels_with_search(
+                        slack_recipients["target"],
+                        types=[
+                            SlackChannelTypes.PRIVATE,
+                            SlackChannelTypes.PUBLIC,
+                        ],
+                    )
                     # we need to ensure that existing reports can also fetch
                     # ids from private channels
                     recipient.recipient_config_json = json.dumps(
                         {
-                            "target": get_channels_with_search(
-                                slack_recipients["target"],
-                                types=[
-                                    SlackChannelTypes.PRIVATE,
-                                    SlackChannelTypes.PUBLIC,
-                                ],
-                            )
+                            "target": ",".join(new_target),
+                            # Save the original target to correctly add
+                            # IMs to new target in future.
+                            "slackV1Target": slack_recipients["target"],
                         }
                     )
+                    # Ensure recipient type updated after new recipient config is set
+                    recipient.type = ReportRecipientType.SLACKV2
         except Exception as ex:
             logger.warning(
                 "Failed to update slack recipients to v2: %s", str(ex), exc_info=True

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 import logging
+import time
 from typing import Optional
 
 from flask import current_app
@@ -26,8 +26,12 @@ from slack_sdk.errors import SlackApiError
 from superset import feature_flag_manager
 from superset.exceptions import SupersetException
 from superset.utils.backports import StrEnum
+from superset.utils import cache as cache_util
+from superset.extensions import cache_manager
 
 logger = logging.getLogger(__name__)
+
+SLACK_CHANNELS_CACHE_TIMEOUT = 60 * 60 * 24 * 2  # 2 days
 
 
 class SlackChannelTypes(StrEnum):
@@ -46,6 +50,37 @@ def get_slack_client() -> WebClient:
     return WebClient(token=token, proxy=current_app.config["SLACK_PROXY"])
 
 
+@cache_util.memoized_func(
+    key="slack_conversations_list",
+    cache=cache_manager.cache,
+)
+def get_channels(types: Optional[list[SlackChannelTypes]] = None, limit: int = 999):
+    client = get_slack_client()
+    channels = []
+    cursor = None
+    extra_params = {}
+    extra_params["types"] = ",".join(types) if types else None
+    while True:
+        try:
+            response = client.conversations_list(
+                limit=limit, cursor=cursor, exclude_archived=True, **extra_params
+            )
+        except SlackApiError as ex:
+            if ex.response.status_code == 429:
+                logger.warning(
+                    "Slack API rate limited. Retrying after %d seconds",
+                    ex.response.headers["retry-after"],
+                )
+                wait_time = int(ex.response.headers["retry-after"]) + 1
+                time.sleep(wait_time)
+                continue
+        channels.extend(response.data["channels"])
+        cursor = response.data.get("response_metadata", {}).get("next_cursor")
+        if not cursor:
+            break
+    return channels
+
+
 def get_channels_with_search(
     search_string: str = "",
     limit: int = 999,
@@ -59,30 +94,18 @@ def get_channels_with_search(
     """
 
     try:
-        client = get_slack_client()
-        channels = []
-        cursor = None
-        extra_params = {}
-        extra_params["types"] = ",".join(types) if types else None
-
-        while True:
-            response = client.conversations_list(
-                limit=limit, cursor=cursor, exclude_archived=True, **extra_params
-            )
-            channels.extend(response.data["channels"])
-            cursor = response.data.get("response_metadata", {}).get("next_cursor")
-            if not cursor:
-                break
-
+        channels = get_channels(
+            types=types, limit=limit, cache_timeout=SLACK_CHANNELS_CACHE_TIMEOUT
+        )
         # The search string can be multiple channels separated by commas
         if search_string:
             search_array = [
-                search.lower()
+                search.lower().strip("#")
                 for search in (search_string.split(",") if search_string else [])
             ]
 
             channels = [
-                channel
+                channel["id"]
                 for channel in channels
                 if any(
                     (


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

* Slack logic for conversations_list API does not handle rate limiting - update to add sleep & retries when we get rate limit errors
* Cache slack channels result
* Some logic errors in Slack channels for file_upload_v2 (strip leading # in channel name, add only channel ids to new target)
* Saving original target string from original recipient config to be able to migrate IM channels to v2 in future (IMs won't be returned in conversations_list)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
