### PR TITLE
fix(query): Return unauthorized response errors as 401 instead of 500

### DIFF
--- a/superset/commands/chart/data/get_data_command.py
+++ b/superset/commands/chart/data/get_data_command.py
@@ -22,6 +22,7 @@ from flask_babel import gettext as _
 from superset.commands.base import BaseCommand
 from superset.commands.chart.exceptions import (
     ChartDataCacheLoadError,
+    ChartDataQueryAuthenticationError,
     ChartDataQueryFailedError,
 )
 from superset.common.query_context import QueryContext
@@ -50,6 +51,19 @@ class ChartDataCommand(BaseCommand):
 
         for query in payload["queries"]:
             if query.get("error"):
+                error_msg = str(query["error"])
+                # Check if this is an authentication error
+                auth_error_indicators = [
+                    "not identified",
+                    "authentication",
+                    "USER_NOT_FOUND",
+                    "unauthorized",
+                    "not authorized",
+                ]
+                if any(indicator.lower() in error_msg.lower() for indicator in auth_error_indicators):
+                    raise ChartDataQueryAuthenticationError(
+                        _("Error: %(error)s", error=query["error"])
+                    )
                 raise ChartDataQueryFailedError(
                     _("Error: %(error)s", error=query["error"])
                 )

--- a/superset/commands/chart/exceptions.py
+++ b/superset/commands/chart/exceptions.py
@@ -136,7 +136,11 @@ class ChartForbiddenError(ForbiddenError):
 
 
 class ChartDataQueryFailedError(CommandException):
-    pass
+    status = 400
+
+
+class ChartDataQueryAuthenticationError(CommandException):
+    status = 401
 
 
 class ChartDataCacheLoadError(CommandException):


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Return authentication errors when trying to execute a query as 401 errors instead of 500 errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Sent a post request that would run a query where the database would return an unauth error
  - before changes would return a 500 response
  - after changes returns a 401 response

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
