### PR TITLE
feat: Add flag to disable dashboard refresh interval

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -62,6 +62,7 @@ export enum FeatureFlag {
   SlackEnableAvatars = 'SLACK_ENABLE_AVATARS',
   EnableDashboardScreenshotEndpoints = 'ENABLE_DASHBOARD_SCREENSHOT_ENDPOINTS',
   EnableDashboardDownloadWebDriverScreenshot = 'ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT',
+  EnableDashboardAutoRefresh = 'ENABLE_DASHBOARD_AUTO_REFRESH',
 }
 
 export type ScheduleQueriesProps = {

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -133,6 +133,9 @@ const redoProps = {
 fetchMock.get('glob:*/csstemplateasyncmodelview/api/read', {});
 
 function setup(props: HeaderProps, initialState = {}) {
+  window.featureFlags = {
+    [uiCore.FeatureFlag.EnableDashboardAutoRefresh]: true,
+  };
   return render(
     <div className="dashboard">
       <Header {...props} />

--- a/superset-frontend/src/dashboard/components/Header/Header.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/Header.test.tsx
@@ -22,6 +22,7 @@ import fetchMock from 'fetch-mock';
 import { getExtensionsRegistry } from '@superset-ui/core';
 import setupExtensions from 'src/setup/setupExtensions';
 import getOwnerName from 'src/utils/getOwnerName';
+import * as uiCore from '@superset-ui/core';
 import { HeaderProps } from './types';
 import Header from '.';
 
@@ -417,4 +418,30 @@ test('should render MetadataBar when not in edit mode and not embedded', () => {
   expect(
     screen.getByText(mockedProps.dashboardInfo.changed_on_delta_humanized),
   ).toBeInTheDocument();
+});
+
+test('should call startPeriodicRender with 0 when ENABLE_DASHBOARD_AUTO_REFRESH feature flag is false', () => {
+  // Save original feature flags
+  // @ts-ignore
+  const originalFeatureFlags = global.featureFlags;
+
+  // @ts-ignore
+  global.featureFlags = {
+    [uiCore.FeatureFlag.EnableDashboardAutoRefresh]: false,
+  };
+
+  const startPeriodicRenderSpy = jest.spyOn(
+    Header.prototype,
+    'startPeriodicRender',
+  );
+
+  const mockedProps = createProps();
+  setup(mockedProps);
+
+  expect(startPeriodicRenderSpy).toHaveBeenCalledWith(0);
+
+  startPeriodicRenderSpy.mockRestore();
+  // Restore original feature flags
+  // @ts-ignore
+  global.featureFlags = originalFeatureFlags;
 });

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';
 import { HeaderDropdownProps } from 'src/dashboard/components/Header/types';
 import injectCustomCss from 'src/dashboard/util/injectCustomCss';
+import * as uiCore from '@superset-ui/core';
 import { HeaderActionsDropdown } from '.';
 
 const createProps = (): HeaderDropdownProps => ({
@@ -225,6 +226,24 @@ test('should show the properties modal', async () => {
   setup(editModeOnProps);
   userEvent.click(screen.getByText('Edit properties'));
   expect(editModeOnProps.showPropertiesModal).toHaveBeenCalledTimes(1);
+});
+
+test('should NOT render "Set auto-refresh interval" when ENABLE_DASHBOARD_AUTO_REFRESH feature flag is false', async () => {
+  const isFeatureEnabledMock = jest
+    .spyOn(uiCore, 'isFeatureEnabled')
+    .mockImplementation(
+      (featureFlag: uiCore.FeatureFlag) =>
+        featureFlag !== uiCore.FeatureFlag.EnableDashboardAutoRefresh,
+    );
+
+  const mockedProps = createProps();
+  setup(mockedProps);
+
+  expect(
+    screen.queryByText('Set auto-refresh interval'),
+  ).not.toBeInTheDocument();
+
+  isFeatureEnabledMock.mockRestore();
 });
 
 describe('UNSAFE_componentWillReceiveProps', () => {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -98,6 +98,9 @@ const guestUserProps = {
 };
 
 function setup(props: HeaderDropdownProps) {
+  window.featureFlags = {
+    [uiCore.FeatureFlag.EnableDashboardAutoRefresh]: true,
+  };
   return render(
     <div className="dashboard-header">
       <HeaderActionsDropdown {...props} />

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.jsx
@@ -20,7 +20,7 @@ import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { connect } from 'react-redux';
-import { t } from '@superset-ui/core';
+import { t, isFeatureEnabled, FeatureFlag } from '@superset-ui/core';
 import { Menu } from 'src/components/Menu';
 import { URL_PARAMS } from 'src/constants';
 import ShareMenuItems from 'src/dashboard/components/menu/ShareMenuItems';
@@ -344,18 +344,20 @@ export class HeaderActionsDropdown extends PureComponent {
           </Menu.Item>
         )}
 
-        <Menu.Item key={MenuKeys.AutorefreshModal}>
-          <RefreshIntervalModal
-            addSuccessToast={this.props.addSuccessToast}
-            refreshFrequency={refreshFrequency}
-            refreshLimit={refreshLimit}
-            refreshWarning={refreshWarning}
-            onChange={this.changeRefreshInterval}
-            editMode={editMode}
-            refreshIntervalOptions={refreshIntervalOptions}
-            triggerNode={<span>{t('Set auto-refresh interval')}</span>}
-          />
-        </Menu.Item>
+        {isFeatureEnabled(FeatureFlag.EnableDashboardAutoRefresh) && (
+          <Menu.Item key={MenuKeys.AutorefreshModal}>
+            <RefreshIntervalModal
+              addSuccessToast={this.props.addSuccessToast}
+              refreshFrequency={refreshFrequency}
+              refreshLimit={refreshLimit}
+              refreshWarning={refreshWarning}
+              onChange={this.changeRefreshInterval}
+              editMode={editMode}
+              refreshIntervalOptions={refreshIntervalOptions}
+              triggerNode={<span>{t('Set auto-refresh interval')}</span>}
+            />
+          </Menu.Item>
+        )}
       </Menu>
     );
   }

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -204,7 +204,12 @@ class Header extends PureComponent {
 
   componentDidMount() {
     const { refreshFrequency } = this.props;
-    this.startPeriodicRender(refreshFrequency * 1000);
+    const refreshInterval = isFeatureEnabled(
+      FeatureFlag.EnableDashboardAutoRefresh,
+    )
+      ? refreshFrequency * 1000
+      : 0;
+    this.startPeriodicRender(refreshInterval);
     Logger.markTimeOrigin();
   }
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -568,6 +568,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # domains in your TALISMAN_CONFIG
     "SLACK_ENABLE_AVATARS": False,
     "ENABLE_COLUMN_VALUES_CACHE": True,
+    # Enable dashboard automatic refresh
+    "ENABLE_DASHBOARD_AUTO_REFRESH": True,
 }
 
 # ------------------------------


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a feature flag ENABLE_DASHBOARD_AUTO_REFRESH to enable/disable the auto-refresh feature
If disabled, the auto-refresh option is hidden from the dashboard menu, and the periodic refresh interval function is called with 0 (indicating no refresh enabled)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API