### PR TITLE
fix(annotations): Pass chart key to annotation logic to fix creation error

### DIFF
--- a/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
+++ b/superset-frontend/src/explore/components/controls/AnnotationLayerControl/index.tsx
@@ -71,6 +71,7 @@ export interface Props {
   onChange: (annotations: Annotation[]) => void;
   refreshAnnotationData: (payload: Payload) => void;
   theme: SupersetTheme;
+  chartKey: string;
 }
 
 export interface PopoverState {
@@ -134,6 +135,7 @@ class AnnotationLayerControl extends PureComponent<Props, PopoverState> {
 
     this.props.refreshAnnotationData({
       annotation: newAnnotation,
+      key: this.props.chartKey,
       force: true,
     });
 
@@ -296,6 +298,7 @@ function mapStateToProps({
     annotationError: chart.annotationError ?? {},
     annotationQuery: chart.annotationQuery ?? {},
     vizType: explore.controls?.viz_type.value,
+    chartKey,
   };
 }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Chart key previously wasn't passed to refreshAnnotationData function, so it is determined by taking the key of the first chart in list of charts in application state
- when chart is loaded from a dashboard context, there are multiple charts in the application state, so the chart key can be incorrectly generated, causing an error & preventing users to add annotations to their charts
- This change fixes the bug by passing the correct chart key to the refreshAnnotationData function

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Tested by adding annotations to a chart loaded from dashboard.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
