### PR TITLE
fix(dashboard): Display generic command errors

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -192,11 +192,19 @@ const FilterValue: FC<FilterControlProps> = ({
                   setState(asyncResult);
                   handleFilterLoadFinish();
                 })
-                .catch((error: Response) => {
-                  getClientErrorObject(error).then(clientErrorObject => {
-                    setError(clientErrorObject);
+                .catch((error: ClientErrorObject | Response) => {
+                  // Check if error is already a parsed error object with errors array
+                  if ('errors' in error && Array.isArray(error.errors)) {
+                    setError(error as ClientErrorObject);
                     handleFilterLoadFinish();
-                  });
+                  } else {
+                    getClientErrorObject(error as Response).then(
+                      clientErrorObject => {
+                        setError(clientErrorObject);
+                        handleFilterLoadFinish();
+                      },
+                    );
+                  }
                 });
             } else {
               throw new Error(
@@ -209,11 +217,17 @@ const FilterValue: FC<FilterControlProps> = ({
             handleFilterLoadFinish();
           }
         })
-        .catch((error: Response) => {
-          getClientErrorObject(error).then(clientErrorObject => {
-            setError(clientErrorObject);
+        .catch((error: ClientErrorObject | Response) => {
+          // Check if error is already a parsed error object with errors array
+          if ('errors' in error && Array.isArray(error.errors)) {
+            setError(error as ClientErrorObject);
             handleFilterLoadFinish();
-          });
+          } else {
+            getClientErrorObject(error as Response).then(clientErrorObject => {
+              setError(clientErrorObject);
+              handleFilterLoadFinish();
+            });
+          }
         });
     }
   }, [

--- a/superset-frontend/src/setup/setupErrorMessages.ts
+++ b/superset-frontend/src/setup/setupErrorMessages.ts
@@ -57,6 +57,10 @@ export default function setupErrorMessages() {
     DatabaseErrorMessage,
   );
   errorMessageComponentRegistry.registerValue(
+    ErrorTypeEnum.GENERIC_COMMAND_ERROR,
+    DatabaseErrorMessage,
+  );
+  errorMessageComponentRegistry.registerValue(
     ErrorTypeEnum.COLUMN_DOES_NOT_EXIST_ERROR,
     DatabaseErrorMessage,
   );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Display rate limiting errors that are returned as `GENERIC_COMMAND_ERROR` when loading charts/filters.
- Register the `GENERIC_COMMAND_ERROR` in the error registry
- Check if the error has already been parsed before trying to parse it in the filters

### BEFORE
<img width="1728" height="735" alt="Screenshot 2026-01-13 at 11 25 30 AM" src="https://github.com/user-attachments/assets/413fb7bb-8aba-44ae-a484-cef7034b1dc0" />


### AFTER
<img width="1728" height="738" alt="Screenshot 2026-01-13 at 11 24 36 AM" src="https://github.com/user-attachments/assets/78b1bba5-daee-4371-916b-fd7e61e6f4fb" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Mocked a rate limiting error on a dashboard to check if the `GENERIC_COMMAND_ERROR` was displaying correctly

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
