### PR TITLE
fix(jwt): Omit subject from JWT so decoding doesn't fail

### DIFF
--- a/superset/async_events/async_query_manager.py
+++ b/superset/async_events/async_query_manager.py
@@ -176,12 +176,14 @@ class AsyncQueryManager:
                 session["async_channel_id"] = async_channel_id
                 session["async_user_id"] = user_id
 
-                sub = str(user_id) if user_id else None
-                token = jwt.encode(
-                    {"channel": async_channel_id, "sub": sub},
-                    self._jwt_secret,
-                    algorithm="HS256",
-                )
+                # NOTE: PyJWT validates that `sub` is a string (if present). Since we
+                # don't use `sub` for async query channel routing, omit it when we
+                # don't have a user_id, and always stringify when we do.
+                payload: dict[str, Any] = {"channel": async_channel_id}
+                if user_id is not None:
+                    payload["sub"] = str(user_id)
+
+                token = jwt.encode(payload, self._jwt_secret, algorithm="HS256")
 
                 response.set_cookie(
                     self._jwt_cookie_name,
@@ -200,7 +202,15 @@ class AsyncQueryManager:
             raise AsyncQueryTokenException("Token not preset")
 
         try:
-            return jwt.decode(token, self._jwt_secret, algorithms=["HS256"])["channel"]
+            # Be tolerant of older cookies that might include `sub` with a non-string
+            # value (eg. null), which PyJWT rejects by default.
+            payload = jwt.decode(
+                token,
+                self._jwt_secret,
+                algorithms=["HS256"],
+                options={"verify_sub": False},
+            )
+            return payload["channel"]
         except Exception as ex:
             logger.warning("Parse jwt failed", exc_info=True)
             raise AsyncQueryTokenException("Failed to parse token") from ex

--- a/tests/unit_tests/async_events/async_query_manager_tests.py
+++ b/tests/unit_tests/async_events/async_query_manager_tests.py
@@ -62,6 +62,25 @@ def test_parse_channel_id_from_request(async_query_manager):
     )
 
 
+def test_parse_channel_id_from_request_with_null_sub(async_query_manager):
+    """
+    Regression test for PyJWT InvalidSubjectError: "Subject must be a string".
+
+    Older async query cookies could include `sub: null`, which PyJWT rejects by
+    default during decode. We only need the `channel` claim.
+    """
+    encoded_token = encode(
+        {"channel": "test_channel_id", "sub": None}, JWT_TOKEN_SECRET, algorithm="HS256"
+    )
+
+    request = Mock()
+    request.cookies = {"superset_async_jwt": encoded_token}
+
+    assert (
+        async_query_manager.parse_channel_id_from_request(request) == "test_channel_id"
+    )
+
+
 def test_parse_channel_id_from_request_no_cookie(async_query_manager):
     request = Mock()
     request.cookies = {}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sometimes when loading a chart, we receive a 401 instead of a 400 error causing a redirection to the `/login` route.
- Omit subject from JWT during encoding when there's no `user_id` to resolve `jwt.exceptions.InvalidSubjectError: Subject must be a string` seen in the console
- When we encode the JWT without the subject, during decoding, the `sub` claim must be a string. Sometimes it is set to `None` and that throws the error
- When the exception is caught in `AsyncQueryManager.parse_channel_id_from_request()`, this may translate that to a `401` error 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- This isn't reliably reproducible 
- Add regression test

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
