### PR TITLE
fix(dataset): Handle string type row_limits  passed in chart query context

### DIFF
--- a/superset/common/query_object_factory.py
+++ b/superset/common/query_object_factory.py
@@ -30,6 +30,7 @@ from superset.utils.core import (
     FilterOperator,
     get_x_axis_label,
     QueryObjectFilterClause,
+    to_int,
 )
 
 if TYPE_CHECKING:
@@ -54,7 +55,8 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         parent_result_type: ChartDataResultType,
         datasource: DatasourceDict | None = None,
         extras: dict[str, Any] | None = None,
-        row_limit: int | None = None,
+        # row_limit: int | None = None,
+        row_limit: Any = None,
         time_range: str | None = None,
         time_shift: str | None = None,
         **kwargs: Any,
@@ -96,14 +98,23 @@ class QueryObjectFactory:  # pylint: disable=too-few-public-methods
         return extras
 
     def _process_row_limit(
-        self, row_limit: int | None, result_type: ChartDataResultType
+        # self, row_limit: int | None, result_type: ChartDataResultType
+        self, row_limit: Any, result_type: ChartDataResultType
     ) -> int:
         default_row_limit = (
             self._config["SAMPLES_ROW_LIMIT"]
             if result_type == ChartDataResultType.SAMPLES
             else self._config["ROW_LIMIT"]
         )
-        return apply_max_row_limit(row_limit or default_row_limit)
+        # return apply_max_row_limit(row_limit or default_row_limit)
+
+        # `row_limit` can come from persisted `query_context` JSON, and may be a string.
+        # Coerce safely to int to avoid TypeError in apply_max_row_limit.
+        if row_limit is None:
+            resolved_row_limit = default_row_limit
+        else:
+            resolved_row_limit = to_int(row_limit, default_row_limit)
+        return apply_max_row_limit(resolved_row_limit)
 
     @staticmethod
     def _process_time_range(

--- a/tests/unit_tests/common/test_query_object_factory.py
+++ b/tests/unit_tests/common/test_query_object_factory.py
@@ -103,6 +103,30 @@ class TestQueryObjectFactory:
         assert query_object.row_limit == 100
         assert query_object.row_offset == 200
 
+    def test_query_context_limit_string_is_coerced(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["row_limit"] = "100"
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.row_limit == 100
+
+    def test_query_context_limit_invalid_string_falls_back_to_default(
+        self,
+        query_object_factory: QueryObjectFactory,
+        raw_query_context: dict[str, Any],
+    ):
+        raw_query_object = raw_query_context["queries"][0]
+        raw_query_object["row_limit"] = "not-a-number"
+        query_object = query_object_factory.create(
+            raw_query_context["result_type"], **raw_query_object
+        )
+        assert query_object.row_limit == 5000
+
     def test_query_context_null_post_processing_op(
         self,
         query_object_factory: QueryObjectFactory,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- In the `get_datasets` endpoint, a new `DatasetValidationError` exception was introduced in v5.0.0. It's being bubbled up instead of a `400` error that was previously in 4.1.1
- When we load certain dashboards, dashboards with a row limit that's been stored as a `string` type in the JSON are raising this new `DatasetValidationError` when we expect an `int` in the backend
- Accept `row_limit` as `Any` and parse it to an int

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Load a dashboard with "invalid" chart query
- See the get `datasets` network call fail

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
