### PR TITLE
fix(filters): Use a BigInt-safe stringify method in dashboard filters modal 

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -108,6 +108,11 @@ import DependencyList from './DependencyList';
 
 const FORM_ITEM_WIDTH = 260;
 
+const stringifyWithBigInt = (value: unknown) =>
+  JSON.stringify(value, (_key, item) =>
+    typeof item === 'bigint' ? item.toString() : item,
+  );
+
 const TabPane = styled(Tabs.TabPane)`
   padding: ${({ theme }) => theme.gridUnit * 4}px 0px;
 `;
@@ -499,7 +504,8 @@ const FiltersConfigForm = (
     });
   }
 
-  const dependenciesText = JSON.stringify(dependenciesDefaultValues);
+  // const dependenciesText = JSON.stringify(dependenciesDefaultValues);
+  const dependenciesText = stringifyWithBigInt(dependenciesDefaultValues);
 
   const refreshHandler = useCallback(
     (force = false) => {
@@ -754,9 +760,12 @@ const FiltersConfigForm = (
     });
     return excluded;
   }, [
-    JSON.stringify(charts),
+    // JSON.stringify(charts),
+    // formFilter?.dataset?.value,
+    // JSON.stringify(loadedDatasets),
+    stringifyWithBigInt(charts),
     formFilter?.dataset?.value,
-    JSON.stringify(loadedDatasets),
+    stringifyWithBigInt(loadedDatasets),
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The filters modal would crash when the chart or datasets included `BigInt` values. Add a BigInt safe stringify method to use instead.

Note: Calling `JSON.stringify` with the "big int" values that were throwing errors did not cause any issues when calling stringify from the browser console

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="1878" height="634" alt="image" src="https://github.com/user-attachments/assets/a3ff78b8-cb0d-479e-9b92-cd7872d0119b" />


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
