### PR TITLE
fix(Pinterest delta table): mixed timeseries logic

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/MixedTimeseries/transformProps.ts
@@ -588,7 +588,7 @@ export default function transformProps(
         ? getDeltaTableTooltipFormatter(
             chartProps,
             () => focusedSeries,
-            primarySeries,
+            new Set(rawSeriesA.map(series => series.name as string)),
           )
         : (params: any) => {
             const xValue: number = richTooltip

--- a/superset-frontend/plugins/plugin-chart-echarts/src/pinterest-utils/tooltip.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/pinterest-utils/tooltip.ts
@@ -86,7 +86,7 @@ class DeltaTableTooltipFormatter {
   constructor(
     chartProps: EchartsTimeseriesChartProps | EchartsMixedTimeseriesProps,
     getFocusedSeries: () => string | null,
-    primarySeriesKeys?: Set<string>,
+    seriesAKeys?: Set<string>,
   ) {
     this.getFocusedSeries = getFocusedSeries;
     const { datasource, queriesData, theme } = chartProps;
@@ -113,7 +113,7 @@ class DeltaTableTooltipFormatter {
           accum[timestamp] = { ...curr };
         } else {
           Object.entries(curr).forEach(([key, value]) => {
-            const currKey = primarySeriesKeys?.has(key)
+            const currKey = seriesAKeys?.has(key)
               ? `${key} (${queryIdx})`
               : key;
             // eslint-disable-next-line no-param-reassign
@@ -346,12 +346,12 @@ class DeltaTableTooltipFormatter {
 export const getDeltaTableTooltipFormatter = (
   chartProps: EchartsTimeseriesChartProps | EchartsMixedTimeseriesProps,
   getFocusedSeries: () => string | null,
-  primarySeriesKeys?: Set<string>,
+  seriesAKeys?: Set<string>,
 ) => {
   const tooltipFormatter = new DeltaTableTooltipFormatter(
     chartProps,
     getFocusedSeries,
-    primarySeriesKeys,
+    seriesAKeys,
   );
   return tooltipFormatter.getTooltipFormatter();
 };


### PR DESCRIPTION
### SUMMARY
Previously, `primarySeriesKeys` was used to distinguish between metrics in query A vs metrics in query B for mixed timeseries charts. This is an incorrect assumption, since primarySeriesKeys just refers to the metrics that are plotted on the primary axis (which could include metrics from both queries). This PR replaces `primarySeriesKeys` with `seriesAKeys` which is a list of the metrics used in query A

### TESTING INSTRUCTIONS
Tested by running locally

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
