### PR TITLE
fix(db): Set flask globals for dashboard, chart, and dataset queries

### DIFF
--- a/superset/commands/chart/data/get_data_command.py
+++ b/superset/commands/chart/data/get_data_command.py
@@ -17,6 +17,7 @@
 import logging
 from typing import Any
 
+from flask import g
 from flask_babel import gettext as _
 
 from superset.commands.base import BaseCommand
@@ -38,6 +39,12 @@ class ChartDataCommand(BaseCommand):
         self._query_context = query_context
 
     def run(self, **kwargs: Any) -> dict[str, Any]:
+        # Set chart context in Flask globals for db_connection_mutator
+        if self._query_context.slice_:
+            g.chart_id = self._query_context.slice_.id
+        if self._query_context.form_data:
+            g.dashboard_id = self._query_context.form_data.get("dashboardId")
+
         # caching is handled in query_context.get_df_payload
         # (also evals `force` property)
         cache_query_context = kwargs.get("cache", False)

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -79,6 +79,7 @@ class DashboardDAO(BaseDAO[Dashboard]):
     @staticmethod
     def get_datasets_for_dashboard(id_or_slug: str) -> list[Any]:
         dashboard = DashboardDAO.get_by_id_or_slug(id_or_slug)
+        g.dashboard_id = dashboard.id
         return dashboard.datasets_trimmed_for_slices()
 
     @staticmethod


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set dashboard and chart ids in the flask globals so that the`db_connection_mutator` doesn't have to parse `form_data`. This also allows the ids to get fetched the same way when looking at synchronous and asynchronous queries.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
