### PR TITLE
test(e2e): Parallelize e2e chart loads

### DIFF
--- a/superset-frontend/cypress-base/cypress/applitools/dashboard.test.ts
+++ b/superset-frontend/cypress-base/cypress/applitools/dashboard.test.ts
@@ -17,13 +17,15 @@
  * under the License.
  */
 import { WORLD_HEALTH_DASHBOARD } from 'cypress/utils/urls';
-import { waitForChartLoad } from 'cypress/utils';
+// import { waitForChartLoad } from 'cypress/utils';
+import { waitForChartsLoad } from 'cypress/utils';
 import { WORLD_HEALTH_CHARTS } from '../e2e/dashboard/utils';
 
 describe('Dashboard load', () => {
   beforeEach(() => {
     cy.visit(WORLD_HEALTH_DASHBOARD);
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
   });
 
   afterEach(() => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.controls.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.controls.test.ts
@@ -18,6 +18,7 @@
  */
 import {
   waitForChartLoad,
+  waitForChartsLoad,
   ChartSpec,
   getChartAliasesBySpec,
 } from 'cypress/utils';
@@ -60,7 +61,8 @@ describe.skip('Dashboard top-level controls', () => {
   it('should allow dashboard level force refresh', () => {
     // when charts are not start loading, for example, under a secondary tab,
     // should allow force refresh
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
     getChartAliasesBySpec(WORLD_HEALTH_CHARTS).then(aliases => {
       cy.get('[aria-label="more-horiz"]').click();
       cy.get('[data-test="refresh-dashboard-menu-item"]').should(

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.key_value.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.key_value.test.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 import qs from 'querystringify';
-import { waitForChartLoad } from 'cypress/utils';
+// import { waitForChartLoad } from 'cypress/utils';
+import { waitForChartsLoad } from 'cypress/utils';
 import { WORLD_HEALTH_DASHBOARD } from 'cypress/utils/urls';
 import { WORLD_HEALTH_CHARTS } from './utils';
 
@@ -33,7 +34,8 @@ describe.skip('nativefilter url param key', () => {
     // things in `before` will not retry and the `waitForChartLoad` check is
     // especially flaky and may need more retries
     cy.visit(WORLD_HEALTH_DASHBOARD);
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
     cy.wait(1000); // wait for key to be published (debounced)
     cy.location().then(loc => {
       const queryParams = qs.parse(loc.search) as QueryString;
@@ -43,7 +45,8 @@ describe.skip('nativefilter url param key', () => {
 
   it('should have different key when page reloads', () => {
     cy.visit(WORLD_HEALTH_DASHBOARD);
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
     cy.wait(1000); // wait for key to be published (debounced)
     cy.location().then(loc => {
       const queryParams = qs.parse(loc.search) as QueryString;

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.url_params.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/_skip.url_params.test.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { parsePostForm, JsonObject, waitForChartLoad } from 'cypress/utils';
+// import { parsePostForm, JsonObject, waitForChartLoad } from 'cypress/utils';
+import { parsePostForm, JsonObject, waitForChartsLoad } from 'cypress/utils';
 import { WORLD_HEALTH_DASHBOARD } from 'cypress/utils/urls';
 import { WORLD_HEALTH_CHARTS } from './utils';
 
@@ -40,6 +41,7 @@ describe.skip('Dashboard form data', () => {
       expect(requestParams.url_params).deep.eq(urlParams);
     });
 
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
   });
 });

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drillby.test.ts
@@ -18,7 +18,8 @@
  */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Interception } from 'cypress/types/net-stubbing';
-import { waitForChartLoad } from 'cypress/utils';
+// import { waitForChartLoad } from 'cypress/utils';
+import { waitForChartsLoad } from 'cypress/utils';
 import { SUPPORTED_CHARTS_DASHBOARD } from 'cypress/utils/urls';
 import {
   openTopLevelTab,
@@ -238,7 +239,8 @@ describe('Drill by modal', () => {
     before(() => {
       closeModal();
       openTopLevelTab('Tier 1');
-      SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      // SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      waitForChartsLoad(SUPPORTED_TIER1_CHARTS);
     });
 
     it('opens the modal from the context menu', () => {
@@ -386,7 +388,8 @@ describe('Drill by modal', () => {
     before(() => {
       closeModal();
       openTopLevelTab('Tier 1');
-      SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      // SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      waitForChartsLoad(SUPPORTED_TIER1_CHARTS);
     });
 
     it('Pivot Table', () => {
@@ -549,7 +552,8 @@ describe('Drill by modal', () => {
     before(() => {
       closeModal();
       openTopLevelTab('Tier 2');
-      SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
+      // SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
+      waitForChartsLoad(SUPPORTED_TIER2_CHARTS);
     });
 
     it('Box Plot Chart', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/drilltodetail.test.ts
@@ -16,7 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { waitForChartLoad } from 'cypress/utils';
+// import { waitForChartLoad } from 'cypress/utils';
+import { waitForChartsLoad } from 'cypress/utils';
 import { SUPPORTED_CHARTS_DASHBOARD } from 'cypress/utils/urls';
 import {
   openTopLevelTab,
@@ -131,7 +132,8 @@ describe('Drill to detail modal', () => {
     before(() => {
       cy.visit(SUPPORTED_CHARTS_DASHBOARD);
       openTopLevelTab('Tier 1');
-      SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      // SUPPORTED_TIER1_CHARTS.forEach(waitForChartLoad);
+      waitForChartsLoad(SUPPORTED_TIER1_CHARTS);
     });
 
     describe('Modal actions', () => {
@@ -432,7 +434,8 @@ describe('Drill to detail modal', () => {
     before(() => {
       cy.visit(SUPPORTED_CHARTS_DASHBOARD);
       openTopLevelTab('Tier 2');
-      SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
+      // SUPPORTED_TIER2_CHARTS.forEach(waitForChartLoad);
+      waitForChartsLoad(SUPPORTED_TIER2_CHARTS);
     });
 
     describe.only('Modal actions', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/load.test.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/load.test.ts
@@ -17,13 +17,15 @@
  * under the License.
  */
 import { WORLD_HEALTH_DASHBOARD } from 'cypress/utils/urls';
-import { waitForChartLoad } from 'cypress/utils';
+// import { waitForChartLoad } from 'cypress/utils';
+import { waitForChartsLoad } from 'cypress/utils';
 import { WORLD_HEALTH_CHARTS, interceptLog } from './utils';
 
 describe('Dashboard load', () => {
   it('should load dashboard', () => {
     cy.visit(WORLD_HEALTH_DASHBOARD);
-    WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    // WORLD_HEALTH_CHARTS.forEach(waitForChartLoad);
+    waitForChartsLoad(WORLD_HEALTH_CHARTS);
   });
 
   it('should load in edit mode', () => {

--- a/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
+++ b/superset-frontend/cypress-base/cypress/e2e/dashboard/utils.ts
@@ -18,7 +18,8 @@
  */
 
 import { dashboardView, nativeFilters } from 'cypress/support/directories';
-import { ChartSpec, waitForChartLoad } from 'cypress/utils';
+// import { ChartSpec, waitForChartLoad } from 'cypress/utils';
+import { ChartSpec, waitForChartsLoad } from 'cypress/utils';
 
 export const WORLD_HEALTH_CHARTS = [
   { name: '% Rural', viz: 'world_map' },
@@ -366,7 +367,8 @@ export function saveNativeFilterSettings(charts: ChartSpec[]) {
     .should('be.visible')
     .click();
   cy.get(nativeFilters.modal.container).should('not.exist');
-  charts.forEach(waitForChartLoad);
+  // charts.forEach(waitForChartLoad);
+  waitForChartsLoad(charts);
 }
 
 /** ************************************************************************

--- a/superset-frontend/cypress-base/cypress/utils/index.ts
+++ b/superset-frontend/cypress-base/cypress/utils/index.ts
@@ -96,6 +96,35 @@ export function waitForChartLoad(chart: ChartSpec) {
 }
 
 /**
+ * Wait for multiple charts to load in parallel.
+ * This collects all chart IDs first, then waits for all of them simultaneously
+ * rather than waiting for each chart sequentially.
+ */
+export function waitForChartsLoad(charts: readonly ChartSpec[]) {
+  const chartIds: string[] = [];
+
+  // Queue up all the chart container checks
+  charts.forEach(({ name, viz }) => {
+    cy.get(`[data-test-chart-name="${name}"]`)
+      .should('have.attr', 'data-test-viz-type', viz)
+      .invoke('attr', 'data-test-chart-id')
+      .then(chartId => {
+        if (chartId) chartIds.push(chartId);
+      });
+  });
+
+  // After all IDs are collected, wait for all charts to be visible
+  // Using a single cy.then() ensures we have all IDs before checking
+  return cy.then(() => {
+    // Create all the visibility checks at once - they'll run in Cypress's queue
+    // but the actual chart loading happens in parallel on the page
+    chartIds.forEach(chartId => {
+      cy.get(`#chart-id-${chartId}`, { timeout: 30000 }).should('be.visible');
+    });
+  });
+}
+
+/**
  * Drag an element and drop it to another element.
  * Usage:
  *    drag(source).to(target);

--- a/superset/commands/chart/data/get_data_command.py
+++ b/superset/commands/chart/data/get_data_command.py
@@ -17,6 +17,7 @@
 import logging
 from typing import Any
 
+from flask import g
 from flask_babel import gettext as _
 
 from superset.commands.base import BaseCommand
@@ -38,6 +39,12 @@ class ChartDataCommand(BaseCommand):
         self._query_context = query_context
 
     def run(self, **kwargs: Any) -> dict[str, Any]:
+        # Set chart context in Flask globals for db_connection_mutator
+        if self._query_context.slice_:
+            g.chart_id = self._query_context.slice_.id
+        if self._query_context.form_data:
+            g.dashboard_id = self._query_context.form_data.get("dashboardId")
+
         # caching is handled in query_context.get_df_payload
         # (also evals `force` property)
         cache_query_context = kwargs.get("cache", False)

--- a/superset/daos/dashboard.py
+++ b/superset/daos/dashboard.py
@@ -79,6 +79,7 @@ class DashboardDAO(BaseDAO[Dashboard]):
     @staticmethod
     def get_datasets_for_dashboard(id_or_slug: str) -> list[Any]:
         dashboard = DashboardDAO.get_by_id_or_slug(id_or_slug)
+        g.dashboard_id = dashboard.id
         return dashboard.datasets_trimmed_for_slices()
 
     @staticmethod


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Some e2e tests were really slow due to heavy `before` hooks, flakiness, and canvas based operations. This PR alleviates some of the heavy `before` hooks that are checking that charts have loaded 1 at a time by running this check for all charts simultaneously. 

### BEFORE
<img width="996" height="434" alt="image" src="https://github.com/user-attachments/assets/29befe51-dcf5-4f2e-8e73-0a2dfcff28ef" />

### AFTER

### TESTING INSTRUCTIONS
- Run e2e tests

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
