### PR TITLE
feat(superset governance): Add pinterest_deleted_at, pinterest_notify_after columns

### DIFF
--- a/superset/migrations/versions/2026-02-12_18-34_e6b95f1e12fb_add_deleted_at_and_notify_after_columns.py
+++ b/superset/migrations/versions/2026-02-12_18-34_e6b95f1e12fb_add_deleted_at_and_notify_after_columns.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Add pinterest_deleted_at and pinterest_notify_after columns for governance
+
+Revision ID: e6b95f1e12fb
+Revises: 74ad1125881c
+Create Date: 2026-02-12 18:34:59.807308
+
+Adds Pinterest-specific columns for dashboard governance soft-deletion and
+garbage collection: pinterest_deleted_at (soft-delete timestamp) and
+pinterest_notify_after (date after which deletion notification should be sent)
+on dashboards; pinterest_deleted_at on slices (charts) and tables (datasets).
+Column names are prefixed with pinterest_ to distinguish from open source columns.
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e6b95f1e12fb"
+down_revision = "74ad1125881c"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.add_column(
+            sa.Column("pinterest_deleted_at", sa.DateTime(), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("pinterest_notify_after", sa.DateTime(), nullable=True)
+        )
+
+    with op.batch_alter_table("slices") as batch_op:
+        batch_op.add_column(
+            sa.Column("pinterest_deleted_at", sa.DateTime(), nullable=True)
+        )
+
+    with op.batch_alter_table("tables") as batch_op:
+        batch_op.add_column(
+            sa.Column("pinterest_deleted_at", sa.DateTime(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("dashboards") as batch_op:
+        batch_op.drop_column("pinterest_notify_after")
+        batch_op.drop_column("pinterest_deleted_at")
+
+    with op.batch_alter_table("slices") as batch_op:
+        batch_op.drop_column("pinterest_deleted_at")
+
+    with op.batch_alter_table("tables") as batch_op:
+        batch_op.drop_column("pinterest_deleted_at")


### PR DESCRIPTION
### SUMMARY
Create alembic migration scripts to create `pinterest_deleted_at` to `dashboards`, `slices`, and `tables` tables to indicate soft-deletion status. Create `pinterest_notify_after` column to `dashboards` to indicate date after which deletion process should begin.

Prepend all custom Pinterest columns with `pinterest_` to differentiate between open source and Pinterest columns.

Alembic heads will need to be merged in future rebases.

### TESTING INSTRUCTIONS
`superset db upgrade head` -> to upgrade
`superset db downgrade <revision>` -> to downgrade

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
