### PR TITLE
feat(superset governance): Create dashboard edit tiering modal stub

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -44,6 +44,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
     '^@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal$':
       '<rootDir>/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx',
+    '^@pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal$':
+      '<rootDir>/pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -42,6 +42,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/chart-controls/controlMap.stub.ts',
     '^@pinterest-plugins/src/explore/components/pinterestChartPills$':
       '<rootDir>/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
+    '^@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal$':
+      '<rootDir>/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx
@@ -1,5 +1,8 @@
 import withToasts from '@superset-frontend/src/components/MessageToasts/withToasts';
-import { UserWithPermissionsAndRoles, UndefinedUser } from '@superset-frontend/src/types/bootstrapTypes';
+import {
+  UserWithPermissionsAndRoles,
+  UndefinedUser,
+} from '@superset-frontend/src/types/bootstrapTypes';
 
 type PinterestPromoteTier1ModalProps = {
   dashboardId: number;
@@ -10,8 +13,8 @@ type PinterestPromoteTier1ModalProps = {
   user: UserWithPermissionsAndRoles | UndefinedUser;
 };
 
-const PinterestPromoteTier1Modal = (_props: PinterestPromoteTier1ModalProps) => (
-  <></>
-);
+const PinterestPromoteTier1Modal = (
+  _props: PinterestPromoteTier1ModalProps,
+) => <></>;
 
 export default withToasts(PinterestPromoteTier1Modal);

--- a/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx
@@ -1,7 +1,7 @@
 import withToasts from '@superset-frontend/src/components/MessageToasts/withToasts';
 import { UserWithPermissionsAndRoles, UndefinedUser } from '@superset-frontend/src/types/bootstrapTypes';
 
-type PinterestTieringInfoModalProps = {
+type PinterestPromoteTier1ModalProps = {
   dashboardId: number;
   show?: boolean;
   onHide: () => void;
@@ -10,8 +10,8 @@ type PinterestTieringInfoModalProps = {
   user: UserWithPermissionsAndRoles | UndefinedUser;
 };
 
-const PinterestTieringInfoModal = (_props: PinterestTieringInfoModalProps) => (
+const PinterestPromoteTier1Modal = (_props: PinterestPromoteTier1ModalProps) => (
   <></>
 );
 
-export default withToasts(PinterestTieringInfoModal);
+export default withToasts(PinterestPromoteTier1Modal);

--- a/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
@@ -3,8 +3,7 @@ import { UserWithPermissionsAndRoles, UndefinedUser } from '@superset-frontend/s
 type PinterestTieringInfoModalProps = {
   dashboardId: number;
   show?: boolean;
-  onHide?: () => void;
-  onSubmit?: (params: Record<string, any>) => void;
+  onHide: () => void;
   addSuccessToast: (message: string) => void;
   addDangerToast: (message: string) => void;
   user: UserWithPermissionsAndRoles | UndefinedUser;

--- a/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
@@ -1,0 +1,17 @@
+import { UserWithPermissionsAndRoles, UndefinedUser } from '@superset-frontend/src/types/bootstrapTypes';
+
+type PinterestTieringInfoModalProps = {
+  dashboardId: number;
+  show?: boolean;
+  onHide?: () => void;
+  onSubmit?: (params: Record<string, any>) => void;
+  addSuccessToast: (message: string) => void;
+  addDangerToast: (message: string) => void;
+  user: UserWithPermissionsAndRoles | UndefinedUser;
+};
+
+const PinterestTieringInfoModal = (_props: PinterestTieringInfoModalProps) => (
+  <></>
+);
+
+export default PinterestTieringInfoModal;

--- a/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx
@@ -1,5 +1,8 @@
 import withToasts from '@superset-frontend/src/components/MessageToasts/withToasts';
-import { UserWithPermissionsAndRoles, UndefinedUser } from '@superset-frontend/src/types/bootstrapTypes';
+import {
+  UserWithPermissionsAndRoles,
+  UndefinedUser,
+} from '@superset-frontend/src/types/bootstrapTypes';
 
 type PinterestTieringInfoModalProps = {
   dashboardId: number;

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/HeaderActionsDropdown.test.tsx
@@ -65,6 +65,8 @@ const createProps = (): HeaderDropdownProps => ({
   userCanSave: false,
   userCanShare: false,
   userCanCurate: false,
+  userCanEditTieringInfo: false,
+  userCanPromoteTier1: false,
   lastModifiedTime: 0,
   isDropdownVisible: true,
   setIsDropdownVisible: jest.fn(),
@@ -74,6 +76,10 @@ const createProps = (): HeaderDropdownProps => ({
   logEvent: jest.fn(),
   refreshLimit: 0,
   refreshWarning: '',
+  showPinterestTieringInfoModal: jest.fn(),
+  hidePinterestTieringInfoModal: jest.fn(),
+  showPinterestPromoteTier1Modal: jest.fn(),
+  hidePinterestPromoteTier1Modal: jest.fn(),
 });
 
 const editModeOnProps = {

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
@@ -112,6 +112,10 @@ export class HeaderActionsDropdown extends PureComponent<
         this.props.manageEmbedded();
         break;
       }
+      case MenuKeys.PinterestTieringInfo: {
+        this.props.showPinterestTieringInfoModal();
+        break;
+      }
       default:
         break;
     }
@@ -259,6 +263,9 @@ export class HeaderActionsDropdown extends PureComponent<
             dashboardComponentId={dashboardComponentId}
           />
         )}
+        <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
+          {t('Edit tiering information')}
+        </Menu.Item>
         {!editMode && userCanCurate && (
           <Menu.Item
             key={MenuKeys.ManageEmbedded}

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
@@ -270,12 +270,18 @@ export class HeaderActionsDropdown extends PureComponent<
           />
         )}
         {editMode && userCanEditTieringInfo && (
-          <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
+          <Menu.Item
+            key={MenuKeys.PinterestTieringInfo}
+            onClick={this.handleMenuClick}
+          >
             {t('Edit tiering information')}
           </Menu.Item>
         )}
         {userCanPromoteTier1 && (
-          <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
+          <Menu.Item
+            key={MenuKeys.PinterestTieringInfo}
+            onClick={this.handleMenuClick}
+          >
             {t('Promote to Tier 1')}
           </Menu.Item>
         )}

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
@@ -139,6 +139,7 @@ export class HeaderActionsDropdown extends PureComponent<
       userCanShare,
       userCanSave,
       userCanCurate,
+      userCanEditTieringInfo,
       isLoading,
       refreshLimit,
       refreshWarning,
@@ -263,9 +264,11 @@ export class HeaderActionsDropdown extends PureComponent<
             dashboardComponentId={dashboardComponentId}
           />
         )}
-        <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
-          {t('Edit tiering information')}
-        </Menu.Item>
+        {userCanEditTieringInfo && (
+          <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
+            {t('Edit tiering information')}
+          </Menu.Item>
+        )}
         {!editMode && userCanCurate && (
           <Menu.Item
             key={MenuKeys.ManageEmbedded}

--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
@@ -116,6 +116,10 @@ export class HeaderActionsDropdown extends PureComponent<
         this.props.showPinterestTieringInfoModal();
         break;
       }
+      case MenuKeys.PinterestPromoteTier1: {
+        this.props.showPinterestPromoteTier1Modal();
+        break;
+      }
       default:
         break;
     }
@@ -140,6 +144,7 @@ export class HeaderActionsDropdown extends PureComponent<
       userCanSave,
       userCanCurate,
       userCanEditTieringInfo,
+      userCanPromoteTier1,
       isLoading,
       refreshLimit,
       refreshWarning,
@@ -264,9 +269,14 @@ export class HeaderActionsDropdown extends PureComponent<
             dashboardComponentId={dashboardComponentId}
           />
         )}
-        {userCanEditTieringInfo && (
+        {editMode && userCanEditTieringInfo && (
           <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
             {t('Edit tiering information')}
+          </Menu.Item>
+        )}
+        {userCanPromoteTier1 && (
+          <Menu.Item key={MenuKeys.PinterestTieringInfo} onClick={this.handleMenuClick}>
+            {t('Promote to Tier 1')}
           </Menu.Item>
         )}
         {!editMode && userCanCurate && (

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -94,6 +94,9 @@ import { useDashboardMetadataBar } from './useDashboardMetadataBar';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestTieringInfoModal from '@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestPromoteTier1Modal from '@pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -167,6 +170,7 @@ const Header = () => {
   const [emphasizeRedo, setEmphasizeRedo] = useState(false);
   const [showingPropertiesModal, setShowingPropertiesModal] = useState(false);
   const [showingPinterestTieringInfoModal, setShowingPinterestTieringInfoModal] = useState(false);
+  const [showingPinterestPromoteTier1Modal, setShowingPinterestPromoteTier1Modal] = useState(false);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [showingEmbedModal, setShowingEmbedModal] = useState(false);
   const dashboardInfo = useSelector(state => state.dashboardInfo);
@@ -502,6 +506,14 @@ const Header = () => {
     setShowingPinterestTieringInfoModal(false);
   }, []);
 
+  const showPinterestPromoteTier1Modal = useCallback(() => {
+    setShowingPinterestPromoteTier1Modal(true);
+  }, []);
+
+  const hidePinterestPromoteTier1Modal = useCallback(() => {
+    setShowingPinterestPromoteTier1Modal(false);
+  }, []);
+
   const showEmbedModal = useCallback(() => {
     setShowingEmbedModal(true);
   }, []);
@@ -526,6 +538,7 @@ const Header = () => {
       ?.SUPERSET_DASHBOARD_PERIODICAL_REFRESH_WARNING_MESSAGE;
   const isEmbedded = !dashboardInfo?.userId;
   const userCanEditTieringInfo = isUserAdmin(user);
+  const userCanPromoteTier1 = isUserAdmin(user);
 
   const handleOnPropertiesChange = useCallback(
     updates => {
@@ -764,6 +777,7 @@ const Header = () => {
         userCanSave={userCanSaveAs}
         userCanCurate={userCanCurate}
         userCanEditTieringInfo={userCanEditTieringInfo}
+        userCanPromoteTier1={userCanPromoteTier1}
         isLoading={isLoading}
         showPropertiesModal={showPropertiesModal}
         manageEmbedded={showEmbedModal}
@@ -775,6 +789,8 @@ const Header = () => {
         logEvent={boundActionCreators.logEvent}
         showPinterestTieringInfoModal={showPinterestTieringInfoModal}
         hidePinterestTieringInfoModal={hidePinterestTieringInfoModal}
+        showPinterestPromoteTier1Modal={showPinterestPromoteTier1Modal}
+        hidePinterestPromoteTier1Modal={hidePinterestPromoteTier1Modal}
       />
     ),
     [
@@ -806,11 +822,13 @@ const Header = () => {
       shouldPersistRefreshFrequency,
       showEmbedModal,
       showPinterestTieringInfoModal,
+      showPinterestPromoteTier1Modal,
       showPropertiesModal,
       startPeriodicRender,
       userCanCurate,
       userCanEdit,
       userCanEditTieringInfo,
+      userCanPromoteTier1,
       userCanSaveAs,
       userCanShare,
     ],
@@ -852,6 +870,14 @@ const Header = () => {
           dashboardId={dashboardInfo.id}
           show={showingPinterestTieringInfoModal}
           onHide={hidePinterestTieringInfoModal}
+          user={user}
+        />
+      )}
+      {showingPinterestPromoteTier1Modal && (
+        <PinterestPromoteTier1Modal
+          dashboardId={dashboardInfo.id}
+          show={showingPinterestPromoteTier1Modal}
+          onHide={hidePinterestPromoteTier1Modal}
           user={user}
         />
       )}

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -40,6 +40,7 @@ import {
 import Icons from 'src/components/Icons';
 import { Button } from 'src/components/';
 import { findPermission } from 'src/utils/findPermission';
+import { isUserAdmin } from 'src/dashboard/util/permissionUtils';
 import { Tooltip } from 'src/components/Tooltip';
 import { safeStringify } from 'src/utils/safeStringify';
 import ConnectedHeaderActionsDropdown from 'src/dashboard/components/Header/HeaderActionsDropdown';
@@ -524,6 +525,7 @@ const Header = () => {
     dashboardInfo.common?.conf
       ?.SUPERSET_DASHBOARD_PERIODICAL_REFRESH_WARNING_MESSAGE;
   const isEmbedded = !dashboardInfo?.userId;
+  const userCanEditTieringInfo = isUserAdmin(user);
 
   const handleOnPropertiesChange = useCallback(
     updates => {
@@ -761,6 +763,7 @@ const Header = () => {
         userCanShare={userCanShare}
         userCanSave={userCanSaveAs}
         userCanCurate={userCanCurate}
+        userCanEditTieringInfo={userCanEditTieringInfo}
         isLoading={isLoading}
         showPropertiesModal={showPropertiesModal}
         manageEmbedded={showEmbedModal}
@@ -807,6 +810,7 @@ const Header = () => {
       startPeriodicRender,
       userCanCurate,
       userCanEdit,
+      userCanEditTieringInfo,
       userCanSaveAs,
       userCanShare,
     ],

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -57,6 +57,12 @@ import setPeriodicRunner, {
   stopPeriodicRender,
 } from 'src/dashboard/util/setPeriodicRunner';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestPromoteTier1Modal from '@pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestTieringInfoModal from '@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
 import {
@@ -91,12 +97,6 @@ import { dashboardInfoChanged } from '../../actions/dashboardInfo';
 import isDashboardLoading from '../../util/isDashboardLoading';
 import { useChartIds } from '../../util/charts/useChartIds';
 import { useDashboardMetadataBar } from './useDashboardMetadataBar';
-// @ts-ignore
-// eslint-disable-next-line import/no-unresolved
-import PinterestTieringInfoModal from '@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal';
-// @ts-ignore
-// eslint-disable-next-line import/no-unresolved
-import PinterestPromoteTier1Modal from '@pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -169,8 +169,14 @@ const Header = () => {
   const [emphasizeUndo, setEmphasizeUndo] = useState(false);
   const [emphasizeRedo, setEmphasizeRedo] = useState(false);
   const [showingPropertiesModal, setShowingPropertiesModal] = useState(false);
-  const [showingPinterestTieringInfoModal, setShowingPinterestTieringInfoModal] = useState(false);
-  const [showingPinterestPromoteTier1Modal, setShowingPinterestPromoteTier1Modal] = useState(false);
+  const [
+    showingPinterestTieringInfoModal,
+    setShowingPinterestTieringInfoModal,
+  ] = useState(false);
+  const [
+    showingPinterestPromoteTier1Modal,
+    setShowingPinterestPromoteTier1Modal,
+  ] = useState(false);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [showingEmbedModal, setShowingEmbedModal] = useState(false);
   const dashboardInfo = useSelector(state => state.dashboardInfo);

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -90,6 +90,9 @@ import { dashboardInfoChanged } from '../../actions/dashboardInfo';
 import isDashboardLoading from '../../util/isDashboardLoading';
 import { useChartIds } from '../../util/charts/useChartIds';
 import { useDashboardMetadataBar } from './useDashboardMetadataBar';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestTieringInfoModal from '@pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -162,6 +165,7 @@ const Header = () => {
   const [emphasizeUndo, setEmphasizeUndo] = useState(false);
   const [emphasizeRedo, setEmphasizeRedo] = useState(false);
   const [showingPropertiesModal, setShowingPropertiesModal] = useState(false);
+  const [showingPinterestTieringInfoModal, setShowingPinterestTieringInfoModal] = useState(false);
   const [isDropdownVisible, setIsDropdownVisible] = useState(false);
   const [showingEmbedModal, setShowingEmbedModal] = useState(false);
   const dashboardInfo = useSelector(state => state.dashboardInfo);
@@ -489,6 +493,14 @@ const Header = () => {
     setShowingPropertiesModal(false);
   }, []);
 
+  const showPinterestTieringInfoModal = useCallback(() => {
+    setShowingPinterestTieringInfoModal(true);
+  }, []);
+
+  const hidePinterestTieringInfoModal = useCallback(() => {
+    setShowingPinterestTieringInfoModal(false);
+  }, []);
+
   const showEmbedModal = useCallback(() => {
     setShowingEmbedModal(true);
   }, []);
@@ -758,6 +770,8 @@ const Header = () => {
         isDropdownVisible={isDropdownVisible}
         setIsDropdownVisible={setDropdownVisible}
         logEvent={boundActionCreators.logEvent}
+        showPinterestTieringInfoModal={showPinterestTieringInfoModal}
+        hidePinterestTieringInfoModal={hidePinterestTieringInfoModal}
       />
     ),
     [
@@ -788,6 +802,7 @@ const Header = () => {
       setDropdownVisible,
       shouldPersistRefreshFrequency,
       showEmbedModal,
+      showPinterestTieringInfoModal,
       showPropertiesModal,
       startPeriodicRender,
       userCanCurate,
@@ -828,7 +843,13 @@ const Header = () => {
           user={user}
         />
       )}
-
+      {showingPinterestTieringInfoModal && (
+        <PinterestTieringInfoModal
+          dashboardId={dashboardInfo.id}
+          show={showingPinterestTieringInfoModal}
+          onHide={hidePinterestTieringInfoModal}
+        />
+      )}
       <OverwriteConfirm />
 
       {userCanCurate && (

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -852,6 +852,7 @@ const Header = () => {
           dashboardId={dashboardInfo.id}
           show={showingPinterestTieringInfoModal}
           onHide={hidePinterestTieringInfoModal}
+          user={user}
         />
       )}
       <OverwriteConfirm />

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -65,6 +65,8 @@ export interface HeaderDropdownProps {
   refreshLimit: number;
   refreshWarning: string;
   directPathToChild: string[];
+  showPinterestTieringInfoModal: () => void;
+  hidePinterestTieringInfoModal: () => void;
 }
 
 export interface HeaderProps {

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -56,6 +56,7 @@ export interface HeaderDropdownProps {
   userCanSave: boolean;
   userCanShare: boolean;
   userCanCurate: boolean;
+  userCanEditTieringInfo?: boolean;
   manageEmbedded: () => void;
   dataMask: any;
   lastModifiedTime: number;

--- a/superset-frontend/src/dashboard/components/Header/types.ts
+++ b/superset-frontend/src/dashboard/components/Header/types.ts
@@ -57,6 +57,7 @@ export interface HeaderDropdownProps {
   userCanShare: boolean;
   userCanCurate: boolean;
   userCanEditTieringInfo?: boolean;
+  userCanPromoteTier1?: boolean;
   manageEmbedded: () => void;
   dataMask: any;
   lastModifiedTime: number;
@@ -68,6 +69,8 @@ export interface HeaderDropdownProps {
   directPathToChild: string[];
   showPinterestTieringInfoModal: () => void;
   hidePinterestTieringInfoModal: () => void;
+  showPinterestPromoteTier1Modal: () => void;
+  hidePinterestPromoteTier1Modal: () => void;
 }
 
 export interface HeaderProps {

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -283,4 +283,5 @@ export enum MenuKeys {
   ManageEmbedded = 'manage_embedded',
   ManageEmailReports = 'manage_email_reports',
   ViewTableInfo = 'view_table_info',
+  PinterestTieringInfo = 'pinterest_tiering_info',
 }

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -284,4 +284,5 @@ export enum MenuKeys {
   ManageEmailReports = 'manage_email_reports',
   ViewTableInfo = 'view_table_info',
   PinterestTieringInfo = 'pinterest_tiering_info',
+  PinterestPromoteTier1 = 'pinterest_promote_tier1',
 }

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -187,6 +187,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/dashboard\/components\/pinterestTieringInfoModal$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx',
+      ),
+    ),
   );
 }
 

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -194,6 +194,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/dashboard/components/pinterestTieringInfoModal.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/dashboard\/components\/pinterestPromoteTier1Modal$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/dashboard/components/pinterestPromoteTier1Modal.stub.tsx',
+      ),
+    ),
   );
 }
 


### PR DESCRIPTION
### SUMMARY
Adds stub for tiering information modal and tier 1 promotion modal in the dashboard's header actions dropdown. Hook up required menu keys and permissions to open modals.

### SCREENSHOTS
#### MENU
<img width="266" height="378" alt="Screenshot 2026-02-18 at 5 11 38 PM" src="https://github.com/user-attachments/assets/3813587b-7d86-4be6-8c8f-dd3f3849c12b" />


#### MENU IN EDIT 
<img width="292" height="365" alt="Screenshot 2026-02-18 at 5 11 43 PM" src="https://github.com/user-attachments/assets/a934238e-e4be-4e20-8f80-a7530dbf4b57" />
MODE

### TESTING INSTRUCTIONS
- Click into dashboard as an admin user
- Check menu dropdown in the header

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
