### PR TITLE
feat(Governance): Create a hook to create Pinterest dashboard properties for new dashboards

### DIFF
--- a/superset/commands/dashboard/copy.py
+++ b/superset/commands/dashboard/copy.py
@@ -19,7 +19,6 @@ from functools import partial
 from typing import Any
 
 from superset import app, is_feature_enabled, security_manager
-from superset.extensions import db
 from superset.commands.base import BaseCommand
 from superset.commands.dashboard.exceptions import (
     DashboardCopyError,
@@ -27,6 +26,7 @@ from superset.commands.dashboard.exceptions import (
     DashboardInvalidError,
 )
 from superset.daos.dashboard import DashboardDAO
+from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.utils.decorators import on_error, transaction
 

--- a/superset/commands/dashboard/copy.py
+++ b/superset/commands/dashboard/copy.py
@@ -18,7 +18,8 @@ import logging
 from functools import partial
 from typing import Any
 
-from superset import is_feature_enabled, security_manager
+from superset import app, is_feature_enabled, security_manager
+from superset.extensions import db
 from superset.commands.base import BaseCommand
 from superset.commands.dashboard.exceptions import (
     DashboardCopyError,
@@ -31,6 +32,9 @@ from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
+config = app.config
+CREATE_PINTEREST_DASHBOARD_PROPERTIES = config["CREATE_PINTEREST_DASHBOARD_PROPERTIES"]
+
 
 class CopyDashboardCommand(BaseCommand):
     def __init__(self, original_dash: Dashboard, data: dict[str, Any]) -> None:
@@ -40,7 +44,14 @@ class CopyDashboardCommand(BaseCommand):
     @transaction(on_error=partial(on_error, reraise=DashboardCopyError))
     def run(self) -> Dashboard:
         self.validate()
-        return DashboardDAO.copy_dashboard(self._original_dash, self._properties)
+        copied_dashboard = DashboardDAO.copy_dashboard(
+            self._original_dash, self._properties
+        )
+        db.session.flush()
+        if CREATE_PINTEREST_DASHBOARD_PROPERTIES:
+            CREATE_PINTEREST_DASHBOARD_PROPERTIES(copied_dashboard.id)
+        db.session.commit()  # pylint: disable=consider-using-transaction
+        return copied_dashboard
 
     def validate(self) -> None:
         if not self._properties.get("dashboard_title") or not self._properties.get(

--- a/superset/commands/dashboard/create.py
+++ b/superset/commands/dashboard/create.py
@@ -21,7 +21,8 @@ from typing import Any, Optional
 from flask_appbuilder.models.sqla import Model
 from marshmallow import ValidationError
 
-from superset import security_manager
+from superset import security_manager, app
+from superset.extensions import db
 from superset.commands.base import BaseCommand, CreateMixin
 from superset.commands.dashboard.exceptions import (
     DashboardCreateFailedError,
@@ -35,6 +36,9 @@ from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)
 
+config = app.config
+CREATE_PINTEREST_DASHBOARD_PROPERTIES = config["CREATE_PINTEREST_DASHBOARD_PROPERTIES"]
+
 
 class CreateDashboardCommand(CreateMixin, BaseCommand):
     def __init__(self, data: dict[str, Any]) -> None:
@@ -43,7 +47,11 @@ class CreateDashboardCommand(CreateMixin, BaseCommand):
     @transaction(on_error=partial(on_error, reraise=DashboardCreateFailedError))
     def run(self) -> Model:
         self.validate()
-        return DashboardDAO.create(attributes=self._properties)
+        new_dashboard = DashboardDAO.create(attributes=self._properties)
+        db.session.flush()
+        if CREATE_PINTEREST_DASHBOARD_PROPERTIES:
+            CREATE_PINTEREST_DASHBOARD_PROPERTIES(new_dashboard.id)
+        return new_dashboard
 
     def validate(self) -> None:
         exceptions: list[ValidationError] = []

--- a/superset/commands/dashboard/create.py
+++ b/superset/commands/dashboard/create.py
@@ -21,8 +21,7 @@ from typing import Any, Optional
 from flask_appbuilder.models.sqla import Model
 from marshmallow import ValidationError
 
-from superset import security_manager, app
-from superset.extensions import db
+from superset import app, security_manager
 from superset.commands.base import BaseCommand, CreateMixin
 from superset.commands.dashboard.exceptions import (
     DashboardCreateFailedError,
@@ -32,6 +31,7 @@ from superset.commands.dashboard.exceptions import (
 )
 from superset.commands.utils import populate_roles
 from superset.daos.dashboard import DashboardDAO
+from superset.extensions import db
 from superset.utils.decorators import on_error, transaction
 
 logger = logging.getLogger(__name__)

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -19,8 +19,8 @@ import logging
 from typing import Any
 
 from superset import app, security_manager
-from superset.extensions import db
 from superset.commands.exceptions import ImportFailedError
+from superset.extensions import db
 from superset.models.dashboard import Dashboard
 from superset.utils import json
 from superset.utils.core import get_user

--- a/superset/commands/dashboard/importers/v1/utils.py
+++ b/superset/commands/dashboard/importers/v1/utils.py
@@ -18,7 +18,8 @@
 import logging
 from typing import Any
 
-from superset import db, security_manager
+from superset import app, security_manager
+from superset.extensions import db
 from superset.commands.exceptions import ImportFailedError
 from superset.models.dashboard import Dashboard
 from superset.utils import json
@@ -26,7 +27,8 @@ from superset.utils.core import get_user
 
 logger = logging.getLogger(__name__)
 
-
+config = app.config
+CREATE_PINTEREST_DASHBOARD_PROPERTIES = config["CREATE_PINTEREST_DASHBOARD_PROPERTIES"]
 JSON_KEYS = {"position": "position_json", "metadata": "json_metadata"}
 
 
@@ -190,6 +192,9 @@ def import_dashboard(  # noqa: C901
     dashboard = Dashboard.import_from_dict(config, recursive=False)
     if dashboard.id is None:
         db.session.flush()
+
+    if CREATE_PINTEREST_DASHBOARD_PROPERTIES:
+        CREATE_PINTEREST_DASHBOARD_PROPERTIES(dashboard.id)
 
     if (user := get_user()) and user not in dashboard.owners:
         dashboard.owners.append(user)

--- a/superset/config.py
+++ b/superset/config.py
@@ -1960,6 +1960,7 @@ COLUMN_VALUES_CACHE_TIMEOUT = 25 * 60 * 60  # 25 hours
 #     pass
 CREATE_PINTEREST_DASHBOARD_PROPERTIES = None
 
+
 # Extra dynamic query filters make it possible to limit which objects are shown
 # in the UI before any other filtering is applied. Useful for example when
 # considering to filter using Feature Flags along with regular role filters

--- a/superset/config.py
+++ b/superset/config.py
@@ -1954,6 +1954,11 @@ PINTEREST_EMAIL_DOMAIN = ""
 # Cache timeout for column values cache (if enabled)
 COLUMN_VALUES_CACHE_TIMEOUT = 25 * 60 * 60  # 25 hours
 
+# [pinterest-specific]: This function is called when a new dashboard is created and
+# creates Pinterest-specific dashboard properties.
+# def create_pinterest_dashboard_properties(dashboard_id: int) -> dict[str, Any]:
+#     pass
+CREATE_PINTEREST_DASHBOARD_PROPERTIES = None
 
 # Extra dynamic query filters make it possible to limit which objects are shown
 # in the UI before any other filtering is applied. Useful for example when

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -25,7 +25,8 @@ from flask_appbuilder.security.decorators import has_access
 from flask_babel import gettext as __
 from flask_login import AnonymousUserMixin, login_user
 
-from superset import db, event_logger, is_feature_enabled
+from superset import app, event_logger, is_feature_enabled
+from superset.extensions import db
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
 from superset.models.dashboard import Dashboard as DashboardModel
 from superset.superset_typing import FlaskResponse
@@ -37,6 +38,9 @@ from superset.views.base import (
     SupersetModelView,
 )
 from superset.views.dashboard.mixin import DashboardMixin
+
+config = app.config
+CREATE_PINTEREST_DASHBOARD_PROPERTIES = config["CREATE_PINTEREST_DASHBOARD_PROPERTIES"]
 
 
 class DashboardModelView(DashboardMixin, SupersetModelView, DeleteMixin):  # pylint: disable=too-many-ancestors
@@ -85,7 +89,10 @@ class Dashboard(BaseSupersetView):
             owners=[g.user],
         )
         db.session.add(new_dashboard)
-        db.session.commit()  # pylint: disable=consider-using-transaction
+        db.session.flush()
+        if CREATE_PINTEREST_DASHBOARD_PROPERTIES:
+            CREATE_PINTEREST_DASHBOARD_PROPERTIES(new_dashboard.id)
+        db.session.commit()
         return redirect(f"/superset/dashboard/{new_dashboard.id}/?edit=true")
 
     @expose("/<dashboard_id_or_slug>/embedded")

--- a/superset/views/dashboard/views.py
+++ b/superset/views/dashboard/views.py
@@ -26,8 +26,8 @@ from flask_babel import gettext as __
 from flask_login import AnonymousUserMixin, login_user
 
 from superset import app, event_logger, is_feature_enabled
-from superset.extensions import db
 from superset.constants import MODEL_VIEW_RW_METHOD_PERMISSION_MAP, RouteMethod
+from superset.extensions import db
 from superset.models.dashboard import Dashboard as DashboardModel
 from superset.superset_typing import FlaskResponse
 from superset.utils import json


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Context: We want to create default PinterestDashboardProperties whenever a new Dashboard is created
Changes:
* create default config variable CREATE_PINTEREST_DASHBOARD_PROPERTIES to define function to create PinterestDashboardProperties
* Update dashboard PUT, copy, import, and /dashboards/new/ endpoint to call CREATE_PINTEREST_DASHBOARD_PROPERTIES config function if it exists

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Tested by running internally and creating dashboards on all endpoints

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
