### PR TITLE
feat(superset governance): Redirect new dashboard with governance props

### DIFF
--- a/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
+++ b/superset-frontend/src/dashboard/components/Header/HeaderActionsDropdown/index.tsx
@@ -269,7 +269,7 @@ export class HeaderActionsDropdown extends PureComponent<
             dashboardComponentId={dashboardComponentId}
           />
         )}
-        {editMode && userCanEditTieringInfo && (
+        {userCanEditTieringInfo && (
           <Menu.Item
             key={MenuKeys.PinterestTieringInfo}
             onClick={this.handleMenuClick}

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -852,9 +852,7 @@ function DashboardList(props: DashboardListProps) {
         }}
         onError={() => {
           setShowTierModal(false);
-          addDangerToast(
-            t('An error occurred while creating the dashboard'),
-          );
+          addDangerToast(t('An error occurred while creating the dashboard'));
           window.location.assign('/dashboard/new');
         }}
       />

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -844,10 +844,17 @@ function DashboardList(props: DashboardListProps) {
       <PinterestNewDashboardTierModal
         show={showTierModal}
         onHide={() => setShowTierModal(false)}
-        onSubmit={() => {
-          // TODO: Set tier info for this new dashboard once redirected to the new dashboard page
-          // with the tier info set in the modal
+        onSubmit={(dashboardId: number) => {
           setShowTierModal(false);
+          window.location.assign(
+            `/superset/dashboard/${dashboardId}/?edit=true`,
+          );
+        }}
+        onError={() => {
+          setShowTierModal(false);
+          addDangerToast(
+            t('An error occurred while creating the dashboard'),
+          );
           window.location.assign('/dashboard/new');
         }}
       />


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Redirects to new dashboard after successful dashboard creation from the `PinterestNewDashboardTierModal`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
