### PR TITLE
fix(slack): Catch slack APIs rate limit error when error code is ratelimited.

### DIFF
--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -77,15 +77,16 @@ def get_channels(
 
             if hasattr(ex.response, "get"):
                 error_code = ex.response.get("error")
-            
+
             if status_code == 429 or error_code == "ratelimited":
-                retry_after = int(ex.response.headers["retry-after"])
+                headers = getattr(ex.response, "headers", {}) or {}
+                retry_after = int(headers.get("retry-after", 30))
 
                 logger.warning(
                     "Slack API rate limited. Retrying after %d seconds",
-                    retry_after
+                    retry_after,
                 )
-            
+
                 wait_time = retry_after + 1
                 time.sleep(wait_time)
                 continue

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -71,7 +71,8 @@ def get_channels(
         except SlackApiError as ex:
             # Check if this is a rate limit error (429)
             # ex.response may be a SlackResponse object or just a string
-            # Slack may surface rate limit errors as HTTP 429 or {'ok': False, 'error': 'ratelimited'}.
+            # Slack may surface rate limit errors as
+            # HTTP 429 or {'ok': False, 'error': 'ratelimited'}.
             status_code = getattr(ex.response, "status_code", None)
             error_code = None
 

--- a/superset/utils/slack.py
+++ b/superset/utils/slack.py
@@ -71,12 +71,22 @@ def get_channels(
         except SlackApiError as ex:
             # Check if this is a rate limit error (429)
             # ex.response may be a SlackResponse object or just a string
-            if hasattr(ex.response, "status_code") and ex.response.status_code == 429:
+            # Slack may surface rate limit errors as HTTP 429 or {'ok': False, 'error': 'ratelimited'}.
+            status_code = getattr(ex.response, "status_code", None)
+            error_code = None
+
+            if hasattr(ex.response, "get"):
+                error_code = ex.response.get("error")
+            
+            if status_code == 429 or error_code == "ratelimited":
+                retry_after = int(ex.response.headers["retry-after"])
+
                 logger.warning(
                     "Slack API rate limited. Retrying after %d seconds",
-                    ex.response.headers["retry-after"],
+                    retry_after
                 )
-                wait_time = int(ex.response.headers["retry-after"]) + 1
+            
+                wait_time = retry_after + 1
                 time.sleep(wait_time)
                 continue
             # Re-raise non-rate-limit errors


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Slack API can surface rate limiting errors as HTTP 429 responses, or `{'ok': False, 'error': 'ratelimited'}`
- Add logic to handle when the error is returned as `'error': 'ratelimited'`
- Also caught an exception when trying to log the `retry-after`, but it's being read as a string so just converting that to int


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
