### PR TITLE
feat(governance): Add stub file for dashboard list page updates

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -54,6 +54,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/governance/pinterestDashboardBanners.stub.tsx',
     '^@pinterest-plugins/src/explore/components/warden/createWardenAlertModal$':
       '<rootDir>/pinterest-plugins/src/explore/components/warden/createWardenAlertModal.stub.tsx',
+    '^@pinterest-plugins/src/features/dashboards/dashboardListExtensions$':
+      '<rootDir>/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
@@ -1,0 +1,20 @@
+/**
+ * Stub for dashboard list extensions (search filters, extra columns).
+ * Internal build replaces this with the real implementation.
+ */
+import { Filter } from 'src/components/ListView/types';
+
+/** Extra search filters to add to the dashboard list (e.g. tier, nimbus_project). */
+export function getDashboardListSearchFilters(): Filter[] {
+  return [];
+}
+
+/** Extra column names to request from the dashboard list API (e.g. tier, nimbus_project). */
+export function getDashboardListExtraColumnsToFetch(): string[] {
+  return [];
+}
+
+/** Extra table column configs for the dashboard list (e.g. Tier, Nimbus Project). */
+export function getDashboardListExtraListColumns(): object[] {
+  return [];
+}

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -125,4 +125,8 @@ export enum FilterOperator {
   ChartTagById = 'chart_tag_id',
   SavedQueryTagByName = 'saved_query_tags',
   SavedQueryTagById = 'saved_query_tag_id',
+  /** Governance: filter by dashboard tier (Tier 1, 2, 3) */
+  Tier = 'tier',
+  /** Governance: filter by Nimbus project */
+  NimbusProject = 'nimbus_project',
 }

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -77,6 +77,8 @@ import {
   getDashboardListExtraColumnsToFetch,
   getDashboardListExtraListColumns,
   getDashboardListSearchFilters,
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
 } from '@pinterest-plugins/src/features/dashboards/dashboardListExtensions';
 
 const PAGE_SIZE = 25;

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -77,8 +77,8 @@ import {
   getDashboardListExtraColumnsToFetch,
   getDashboardListExtraListColumns,
   getDashboardListSearchFilters,
-// @ts-ignore
-// eslint-disable-next-line import/no-unresolved
+  // @ts-ignore
+  // eslint-disable-next-line import/no-unresolved
 } from '@pinterest-plugins/src/features/dashboards/dashboardListExtensions';
 
 const PAGE_SIZE = 25;
@@ -184,7 +184,10 @@ function DashboardList(props: DashboardListProps) {
     undefined,
     undefined,
     undefined,
-    [...DASHBOARD_COLUMNS_TO_FETCH, ...(isUserAdmin(reduxUser) ? getDashboardListExtraColumnsToFetch() : [])],
+    [
+      ...DASHBOARD_COLUMNS_TO_FETCH,
+      ...(isUserAdmin(reduxUser) ? getDashboardListExtraColumnsToFetch() : []),
+    ],
   );
   const dashboardIds = useMemo(() => dashboards.map(d => d.id), [dashboards]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -182,7 +182,7 @@ function DashboardList(props: DashboardListProps) {
     undefined,
     undefined,
     undefined,
-    [...DASHBOARD_COLUMNS_TO_FETCH, ...getDashboardListExtraColumnsToFetch()],
+    [...DASHBOARD_COLUMNS_TO_FETCH, ...(isUserAdmin(reduxUser) ? getDashboardListExtraColumnsToFetch() : [])],
   );
   const dashboardIds = useMemo(() => dashboards.map(d => d.id), [dashboards]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
@@ -373,7 +373,7 @@ function DashboardList(props: DashboardListProps) {
         accessor: 'published',
         size: 'xl',
       },
-      ...getDashboardListExtraListColumns(),
+      ...(isUserAdmin(reduxUser) ? getDashboardListExtraListColumns() : []),
       {
         Cell: ({
           row: {
@@ -631,7 +631,7 @@ function DashboardList(props: DashboardListProps) {
         ),
         paginate: true,
       },
-      ...getDashboardListSearchFilters(),
+      ...(isUserAdmin(reduxUser) ? getDashboardListSearchFilters() : []),
     ] as Filters;
     return filters_list;
   }, [addDangerToast, favoritesFilter, props.user]);

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -73,6 +73,11 @@ import { ModifiedInfo } from 'src/components/AuditInfo';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestNewDashboardTierModal from '@pinterest-plugins/src/governance/pinterestNewDashboardTierModal';
+import {
+  getDashboardListExtraColumnsToFetch,
+  getDashboardListExtraListColumns,
+  getDashboardListSearchFilters,
+} from '@pinterest-plugins/src/features/dashboards/dashboardListExtensions';
 
 const PAGE_SIZE = 25;
 const PASSWORDS_NEEDED_MESSAGE = t(
@@ -111,6 +116,10 @@ export interface Dashboard {
   owners: Owner[];
   tags: Tag[];
   created_by: object;
+  /** Governance (internal): tier '1' | '2' | '3' */
+  tier?: string;
+  /** Governance (internal): Nimbus project name */
+  nimbus_project?: string;
 }
 
 const Actions = styled.div`
@@ -173,7 +182,7 @@ function DashboardList(props: DashboardListProps) {
     undefined,
     undefined,
     undefined,
-    DASHBOARD_COLUMNS_TO_FETCH,
+    [...DASHBOARD_COLUMNS_TO_FETCH, ...getDashboardListExtraColumnsToFetch()],
   );
   const dashboardIds = useMemo(() => dashboards.map(d => d.id), [dashboards]);
   const [saveFavoriteStatus, favoriteStatus] = useFavoriteStatus(
@@ -364,6 +373,7 @@ function DashboardList(props: DashboardListProps) {
         accessor: 'published',
         size: 'xl',
       },
+      ...getDashboardListExtraListColumns(),
       {
         Cell: ({
           row: {
@@ -621,6 +631,7 @@ function DashboardList(props: DashboardListProps) {
         ),
         paginate: true,
       },
+      ...getDashboardListSearchFilters(),
     ] as Filters;
     return filters_list;
   }, [addDangerToast, favoritesFilter, props.user]);

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -229,6 +229,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/explore/components/warden/createWardenAlertModal.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/features\/dashboards\/dashboardListExtensions$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx',
+      ),
+    ),
   );
 }
 

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -30,8 +30,6 @@ from flask_appbuilder.models.filters import Filters
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext, ngettext
 from marshmallow import ValidationError
-from sqlalchemy import case, func
-from sqlalchemy.orm import Query
 from werkzeug.wrappers import Response as WerkzeugResponse
 from werkzeug.wsgi import FileWrapper
 
@@ -106,12 +104,7 @@ from superset.dashboards.schemas import (
     thumbnail_query_schema,
 )
 from superset.extensions import event_logger
-from superset.models.core import FavStar, FavStarClassName
-from superset.models.dashboard import (
-    Dashboard,
-    DEPRECATED_TITLE_PENALTY,
-    MISSING_TITLE_PENALTY,
-)
+from superset.models.dashboard import Dashboard
 from superset.models.embedded_dashboard import EmbeddedDashboard
 from superset.security.guest_token import GuestUser
 from superset.tasks.thumbnails import (
@@ -392,107 +385,6 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             self.appbuilder.app.config["VERSION_STRING"],
             self.appbuilder.app.config["VERSION_SHA"],
         )
-
-    def __init__(self) -> None:
-        super().__init__()
-        original_apply_order_by = self.datamodel.apply_order_by
-
-        # Override the apply_order_by method to handle relevance_score ordering
-        def custom_apply_order_by(
-            query: Query,
-            order_column: str,
-            order_direction: str,
-            **kwargs: Any,
-        ) -> Query:
-            if order_column == "relevance_score":
-                # Clear any existing ordering
-                query = query.order_by(None)
-
-                # Create a pre-aggregated subquery that counts favorites per dashboard
-                favstar_counts = (
-                    db.session.query(
-                        FavStar.obj_id.label("dashboard_id"),
-                        func.count(FavStar.id).label("favorite_count"),
-                    )
-                    .filter(FavStar.class_name == FavStarClassName.DASHBOARD)
-                    .group_by(FavStar.obj_id)
-                    .subquery()
-                )
-
-                # Join with the pre-aggregated favorite counts
-                query = query.outerjoin(
-                    favstar_counts, favstar_counts.c.dashboard_id == Dashboard.id
-                )
-
-                favorite_count = func.coalesce(favstar_counts.c.favorite_count, 0)
-
-                # Calculate title penalties (same logic as in the model)
-                title_penalty = case(
-                    [
-                        (
-                            Dashboard.dashboard_title.is_(None),
-                            MISSING_TITLE_PENALTY,
-                        ),
-                        (
-                            func.lower(func.trim(Dashboard.dashboard_title)).like(
-                                "[ untitled ]%"
-                            ),
-                            MISSING_TITLE_PENALTY,
-                        ),
-                    ],
-                    else_=0,
-                ) + case(
-                    [
-                        (
-                            func.lower(func.trim(Dashboard.dashboard_title)).like(
-                                "[deprecated]%"
-                            ),
-                            DEPRECATED_TITLE_PENALTY,
-                        ),
-                        (
-                            func.lower(func.trim(Dashboard.dashboard_title)).like(
-                                "%[deprecated]"
-                            ),
-                            DEPRECATED_TITLE_PENALTY,
-                        ),
-                        (
-                            func.lower(func.trim(Dashboard.dashboard_title)).like(
-                                "(deprecated)%"
-                            ),
-                            DEPRECATED_TITLE_PENALTY,
-                        ),
-                        (
-                            func.lower(func.trim(Dashboard.dashboard_title)).like(
-                                "%(deprecated)"
-                            ),
-                            DEPRECATED_TITLE_PENALTY,
-                        ),
-                    ],
-                    else_=0,
-                )
-
-                # Calculate relevance score (same logic as in the model)
-                relevance_score = favorite_count - title_penalty
-
-                if order_direction == "desc":
-                    return query.order_by(
-                        relevance_score.desc(),
-                        Dashboard.published.desc(),
-                        Dashboard.dashboard_title.asc(),
-                    )
-                else:
-                    return query.order_by(
-                        relevance_score.asc(),
-                        Dashboard.published.asc(),
-                        Dashboard.dashboard_title.asc(),
-                    )
-
-            # For all other columns, use the original method
-            return original_apply_order_by(
-                query, order_column, order_direction, **kwargs
-            )
-
-        self.datamodel.apply_order_by = custom_apply_order_by
 
     @expose("/<id_or_slug>", methods=("GET",))
     @protect()
@@ -1900,9 +1792,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @permission_name("set_embedded")
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self,
-        *args,
-        **kwargs: f"{self.__class__.__name__}.delete_embedded",
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete_embedded",
         log_to_statsd=False,
     )
     @with_dashboard

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -172,7 +172,7 @@ class DashboardSQLAInterface(SQLAInterface):
     def get_filters(
         self,
         search_columns: Optional[list[str]] = None,
-        search_filters: Optional[dict] = None,
+        search_filters: Optional[dict[Any, Any]] = None,
         **kwargs: Any,
     ) -> Filters:
         # Build base Filters without merging search_filters, so synthetic

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -26,6 +26,7 @@ from flask import g, redirect, request, Response, send_file, url_for
 from flask_appbuilder import permission_name
 from flask_appbuilder.api import expose, protect, rison, safe
 from flask_appbuilder.hooks import before_request
+from flask_appbuilder.models.filters import Filters
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import gettext, ngettext
 from marshmallow import ValidationError
@@ -166,9 +167,39 @@ def with_dashboard(
     return functools.update_wrapper(wraps, f)
 
 
+class DashboardSQLAInterface(SQLAInterface):
+    """
+    Custom SQLAInterface so search_filters can include keys (e.g. tier,
+    nimbus_project) that are not on the Dashboard table. FAB's Filters
+    only pre-fills _search_filters from model columns, so extra keys
+    cause KeyError when merging. This override ensures every
+    search_column and every search_filter key has an entry before merge.
+    """
+
+    def get_filters(
+        self,
+        search_columns: Optional[list[str]] = None,
+        search_filters: Optional[dict] = None,
+        **kwargs: Any,
+    ) -> Filters:
+        # Build base Filters without merging search_filters, so synthetic
+        # keys do not trigger KeyError. Then add keys and merge ourselves.
+        try:
+            filters = super().get_filters(search_columns, {}, **kwargs)
+        except TypeError:
+            # Parent may only take search_columns
+            filters = super().get_filters(search_columns)
+        for col in search_columns or []:
+            filters._search_filters.setdefault(col, [])
+        if search_filters:
+            for key, filter_list in search_filters.items():
+                filters._search_filters.setdefault(key, []).extend(filter_list)
+        return filters
+
+
 # pylint: disable=too-many-public-methods
 class DashboardRestApi(BaseSupersetModelRestApi):
-    datamodel = SQLAInterface(Dashboard)
+    datamodel = DashboardSQLAInterface(Dashboard)
 
     # Removing thumbnail endpoint from this list to support caching top Pinterest
     # homepage dashboards without THUMBNAILS feature enabled to cache all dashboards

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -1792,7 +1792,9 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     @permission_name("set_embedded")
     @statsd_metrics
     @event_logger.log_this_with_context(
-        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.delete_embedded",
+        action=lambda self, *args, **kwargs: (
+            f"{self.__class__.__name__}.delete_embedded"
+        ),
         log_to_statsd=False,
     )
     @with_dashboard


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

We are supporting custom internal dashboard list page filters & columns

- Backend (dashboards API): Add DashboardSQLAInterface so list search can use synthetic columns (tier, nimbus_project) without KeyError; FAB’s Filters no longer assumes every key exists on the model.
- Dashboard list page: Use configurable search filters and extra list columns from dashboardListExtensions (stub in public, full impl in internal build);
- ListView types: Add FilterOperator.Tier and FilterOperator.NimbusProject for the new filters.
- Stub: Add dashboardListExtensions.stub.tsx in pinterest-plugins (empty filters, empty extra columns to fetch, empty extra list columns) for open-source builds.
- Webpack / Jest: Add module replacement so @pinterest-plugins/.../dashboardListExtensions resolves to the stub when internal plugins are disabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
