### PR TITLE
fix(filters): Convert relevance_score to a hybrid property

### DIFF
--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -389,25 +389,25 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
         return score
 
     @relevance_score.expression  # type: ignore[misc]
-    def relevance_score(cls) -> sqla.sql.Selectable:
+    def relevance_score(self) -> sqla.sql.Selectable:
         favorite_count = (
             sqla.select(sqla.func.count(FavStar.id))
             .where(
                 sqla.and_(
-                    FavStar.obj_id == cls.id,
+                    FavStar.obj_id == self.id,
                     FavStar.class_name == "Dashboard",
                 )
             )
             .scalar_subquery()
         )
         title_lower = sqla.func.lower(
-            sqla.func.trim(sqla.func.coalesce(cls.dashboard_title, ""))
+            sqla.func.trim(sqla.func.coalesce(self.dashboard_title, ""))
         )
 
         missing_title_penalty = sqla.case(
             (
                 sqla.or_(
-                    cls.dashboard_title.is_(None),
+                    self.dashboard_title.is_(None),
                     title_lower == "",
                     title_lower.startswith("[ untitled ]"),
                 ),

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -388,8 +388,8 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
         return score
 
-    @relevance_score.expression
-    def _relevance_score_expression(self) -> sqla.sql.Selectable:
+    @relevance_score.expression  # type: ignore[no-redef]
+    def relevance_score(self) -> sqla.sql.Selectable:
         favorite_count = (
             sqla.select(sqla.func.count(FavStar.id))
             .where(

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -388,8 +388,8 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
         return score
 
-    @relevance_score.expression  # type: ignore[misc]
-    def relevance_score(self) -> sqla.sql.Selectable:
+    @relevance_score.expression
+    def _relevance_score_expression(self) -> sqla.sql.Selectable:
         favorite_count = (
             sqla.select(sqla.func.count(FavStar.id))
             .where(

--- a/superset/models/dashboard.py
+++ b/superset/models/dashboard.py
@@ -37,6 +37,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.engine.base import Connection
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, subqueryload
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy.sql.elements import BinaryExpression
@@ -360,7 +361,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
 
         return {"all_tabs": all_tabs, "tab_tree": tab_tree}
 
-    @property
+    @hybrid_property
     def relevance_score(self) -> float:
         """
         Returns a relevance score for the dashboard based on its favorite count.
@@ -372,7 +373,7 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
             score -= MISSING_TITLE_PENALTY
             return score
         if self.dashboard_title:
-            title_lower = self.dashboard_title.lower().trim()
+            title_lower = self.dashboard_title.lower().strip()
 
             if title_lower.startswith("[ untitled ]"):
                 score -= MISSING_TITLE_PENALTY
@@ -386,6 +387,48 @@ class Dashboard(AuditMixinNullable, ImportExportMixin, Model):
                 score -= DEPRECATED_TITLE_PENALTY
 
         return score
+
+    @relevance_score.expression  # type: ignore[misc]
+    def relevance_score(cls) -> sqla.sql.Selectable:
+        favorite_count = (
+            sqla.select(sqla.func.count(FavStar.id))
+            .where(
+                sqla.and_(
+                    FavStar.obj_id == cls.id,
+                    FavStar.class_name == "Dashboard",
+                )
+            )
+            .scalar_subquery()
+        )
+        title_lower = sqla.func.lower(
+            sqla.func.trim(sqla.func.coalesce(cls.dashboard_title, ""))
+        )
+
+        missing_title_penalty = sqla.case(
+            (
+                sqla.or_(
+                    cls.dashboard_title.is_(None),
+                    title_lower == "",
+                    title_lower.startswith("[ untitled ]"),
+                ),
+                MISSING_TITLE_PENALTY,
+            ),
+            else_=0,
+        )
+        deprecated_title_penalty = sqla.case(
+            (
+                sqla.or_(
+                    title_lower.startswith("[deprecated]"),
+                    title_lower.endswith("[deprecated]"),
+                    title_lower.startswith("(deprecated)"),
+                    title_lower.endswith("(deprecated)"),
+                ),
+                DEPRECATED_TITLE_PENALTY,
+            ),
+            else_=0,
+        )
+
+        return favorite_count - missing_title_penalty - deprecated_title_penalty
 
     def update_thumbnail(self) -> None:
         cache_dashboard_thumbnail.delay(


### PR DESCRIPTION
The `relevance_score` couldn't be used as a fallback filter if it wasn't made a `hybrid_property` throwing a MySQL error on the dashboard list page. The dashboard list e2e test was also failing without this change.