### PR TITLE
feat(helix-ultra): Add SQLLab Helix Ultra integration

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -56,6 +56,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/explore/components/warden/createWardenAlertModal.stub.tsx',
     '^@pinterest-plugins/src/features/dashboards/dashboardListExtensions$':
       '<rootDir>/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx',
+    '^@pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras$':
+      '<rootDir>/pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx
@@ -1,0 +1,1 @@
+export const getPinterestSqlLabToolbarExtras = () => <></>;

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -114,6 +114,9 @@ import {
   LOG_ACTIONS_SQLLAB_STOP_QUERY,
   Logger,
 } from 'src/logger/LogUtils';
+// @ts-ignore -- resolved by @pinterest-plugins alias; stubbed when USE_PINTEREST_PLUGINS !== 'true'
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestSqlLabToolbarExtras } from '@pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras';
 import TemplateParamsEditor from '../TemplateParamsEditor';
 import SouthPane from '../SouthPane';
 import SaveQuery, { QueryPayload } from '../SaveQuery';
@@ -124,9 +127,6 @@ import SqlEditorLeftBar from '../SqlEditorLeftBar';
 import AceEditorWrapper from '../AceEditorWrapper';
 import RunQueryActionButton from '../RunQueryActionButton';
 import QueryLimitSelect from '../QueryLimitSelect';
-// @ts-ignore -- resolved by @pinterest-plugins alias; stubbed when USE_PINTEREST_PLUGINS !== 'true'
-// eslint-disable-next-line import/no-unresolved
-import { getPinterestSqlLabToolbarExtras } from '@pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras';
 import KeyboardShortcutButton, {
   KEY_MAP,
   KeyboardShortcut,

--- a/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
+++ b/superset-frontend/src/SqlLab/components/SqlEditor/index.tsx
@@ -124,6 +124,9 @@ import SqlEditorLeftBar from '../SqlEditorLeftBar';
 import AceEditorWrapper from '../AceEditorWrapper';
 import RunQueryActionButton from '../RunQueryActionButton';
 import QueryLimitSelect from '../QueryLimitSelect';
+// @ts-ignore -- resolved by @pinterest-plugins alias; stubbed when USE_PINTEREST_PLUGINS !== 'true'
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestSqlLabToolbarExtras } from '@pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras';
 import KeyboardShortcutButton, {
   KEY_MAP,
   KeyboardShortcut,
@@ -855,6 +858,7 @@ const SqlEditor: FC<Props> = ({
               )}
             </div>
             <div className="rightItems">
+              <span>{getPinterestSqlLabToolbarExtras()}</span>
               <span>
                 <SaveQuery
                   queryEditorId={queryEditor.id}

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -236,6 +236,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/sqllab\/pinterestSqlLabToolbarExtras$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx',
+      ),
+    ),
   );
 }
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -1963,6 +1963,15 @@ COLUMN_VALUES_CACHE_TIMEOUT = 25 * 60 * 60  # 25 hours
 #     pass
 CREATE_PINTEREST_DASHBOARD_PROPERTIES = None
 
+# [pinterest-specific]: This function is called when dashboard owners are updated
+# via PUT and syncs ownership to external Pinterest systems.
+# def sync_pinterest_dashboard_ownership(
+#     dashboard_id: int,
+#     technical_owner_usernames: list[str],
+# ) -> None:
+#     pass
+SYNC_PINTEREST_DASHBOARD_OWNERSHIP = None
+
 
 # Extra dynamic query filters make it possible to limit which objects are shown
 # in the UI before any other filtering is applied. Useful for example when


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add Helix Ultra integration in SQLLab query editor toolbar.

- SQLLab page: Render toolbar extras including Helix Ultra entry point (stub in public, full impl in internal build);
- Stub: Add pinterestSqlLabToolbarExtras.stub.tsx in pinterest-plugins (empty filters, empty extra columns to fetch, empty extra list columns) for open-source builds.
- Webpack / Jest: Add module replacement so @pinterest-plugins/.../pinterestSqlLabToolbarExtras resolves to the stub when internal plugins are disabled.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
