### PR TITLE
feat(helix-ultra): Add helix ultra integration to chart view

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -58,6 +58,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx',
     '^@pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras$':
       '<rootDir>/pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx',
+    '^@pinterest-plugins/src/dashboard/pinterestChartHeaderExtras$':
+      '<rootDir>/pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx
@@ -1,0 +1,1 @@
+export const getPinterestChartHeaderExtras = (_?: number) => <></>;

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -31,6 +31,9 @@ import { sliceUpdated } from 'src/explore/actions/exploreActions';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { setSaveChartModalVisibility } from 'src/explore/actions/saveModalActions';
 import { applyColors, resetColors } from 'src/utils/colorScheme';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestChartHeaderExtras } from '@pinterest-plugins/src/dashboard/pinterestChartHeaderExtras';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 import { useExploreMetadataBar } from './useExploreMetadataBar';
 
@@ -50,6 +53,13 @@ const propTypes = {
   chart: chartPropShape,
   saveDisabled: PropTypes.bool,
 };
+
+const buttonContainerStyles = theme => css`
+  align-items: center;
+  display: flex;
+  gap: ${theme.gridUnit * 2}px;
+  margin-left: ${theme.gridUnit}px;
+`;
 
 const saveButtonStyles = theme => css`
   color: ${theme.colors.primary.dark2};
@@ -205,27 +215,30 @@ export const ExploreChartHeader = ({
           </div>
         }
         rightPanelAdditionalItems={
-          <Tooltip
-            title={
-              saveDisabled
-                ? t('Add required control values to save chart')
-                : null
-            }
-          >
-            {/* needed to wrap button in a div - antd tooltip doesn't work with disabled button */}
-            <div>
-              <Button
-                buttonStyle="secondary"
-                onClick={showModal}
-                disabled={saveDisabled}
-                data-test="query-save-button"
-                css={saveButtonStyles}
-              >
-                <Icons.SaveOutlined iconSize="l" />
-                {t('Save')}
-              </Button>
-            </div>
-          </Tooltip>
+          <div css={buttonContainerStyles}>
+            {getPinterestChartHeaderExtras(slice?.slice_id)}
+            <Tooltip
+              title={
+                saveDisabled
+                  ? t('Add required control values to save chart')
+                  : null
+              }
+            >
+              {/* needed to wrap button in a div - antd tooltip doesn't work with disabled button */}
+              <div>
+                <Button
+                  buttonStyle="secondary"
+                  onClick={showModal}
+                  disabled={saveDisabled}
+                  data-test="query-save-button"
+                  css={saveButtonStyles}
+                >
+                  <Icons.SaveOutlined iconSize="l" />
+                  {t('Save')}
+                </Button>
+              </div>
+            </Tooltip>
+          </div>
         }
         additionalActionsMenu={menu}
         menuDropdownProps={{

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -58,7 +58,6 @@ const buttonContainerStyles = theme => css`
   align-items: center;
   display: flex;
   gap: ${theme.gridUnit * 2}px;
-  margin-left: ${theme.gridUnit}px;
 `;
 
 const saveButtonStyles = theme => css`

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -243,6 +243,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/dashboard\/pinterestChartHeaderExtras$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx',
+      ),
+    ),
   );
 }
 


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Add Helix Ultra integration in Explore Chart header.

- Explore Chart page: Render header extras including Helix Ultra entry point (stub in public, full impl in internal build);
- Stub: Add pinterestChartHeaderExtras.stub.tsx‎ in pinterest-plugins for open-source builds.
- Webpack / Jest: Add module replacement so @pinterest-plugins/.../pinterestChartHeaderExtras resolves to the stub when internal plugins are disabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
