### PR TITLE
fix(filters): Surface async websocket errors

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/FilterValue.tsx
@@ -54,7 +54,6 @@ import {
 } from 'src/dashboard/actions/dashboardState';
 import { RESPONSIVE_WIDTH } from 'src/filters/components/common';
 import { FAST_DEBOUNCE } from 'src/constants';
-import ErrorAlert from 'src/components/ErrorMessage/ErrorAlert';
 import { dispatchHoverAction, dispatchFocusAction } from './utils';
 import { FilterControlProps } from './types';
 import { getFormData } from '../../utils';
@@ -317,18 +316,13 @@ const FilterValue: FC<FilterControlProps> = ({
   );
 
   if (error) {
+    const structuredError = error.errors?.[0];
     return (
       <ErrorMessageWithStackTrace
-        error={error.errors?.[0]}
+        error={structuredError}
         compact
-        fallback={
-          <ErrorAlert
-            errorType={t('Network error')}
-            message={t('Network error while attempting to fetch resource')}
-            type="error"
-            compact
-          />
-        }
+        title={t('Error loading filter')}
+        description={structuredError?.message || error.error}
       />
     );
   }


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`FilterValue.tsx` always passes a fallback, and `ErrorMessageWithStackTrace` renders that fallback whenever there isn’t a custom registered error component. That means even structured websocket errors are getting masked by the generic “Network error” banner.

`waitForAsyncData()`  already rejects the async `status: error` payload, but `FilterValue.tsx` masks it with a hardcoded fallback. 

This PR removes the fallback in `FilterValue`. It now passes the structured async error through `ErrorMessageWithStackTrace` and uses `structuredError?.message || error.error` as the description, so messages coming from websocket status: "error" events should show up in the filter UI.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before
<img width="754" height="305" alt="Screenshot 2026-04-13 at 5 11 49 PM" src="https://github.com/user-attachments/assets/be84d96f-df14-4216-add4-1e27949e7402" />

#### After


<img width="876" height="375" alt="Screenshot 2026-04-13 at 5 12 04 PM" src="https://github.com/user-attachments/assets/5e03027b-b0fb-43dc-8e0e-bcb710fd0f27" />

### TESTING INSTRUCTIONS
- Manually verified by loading a dashboard with problematic filters

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
