### PR TITLE
fix(charts): Preserve backend error payload for chart failures

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -240,7 +240,15 @@ class Chart extends PureComponent<ChartProps, {}> {
       datasetsStatus,
     } = this.props;
     const error = queryResponse?.errors?.[0];
-    const message = chartAlert || queryResponse?.message;
+    // const message = chartAlert || queryResponse?.message;
+    const message =
+      queryResponse?.errors?.[0]?.message ||
+      chartAlert ||
+      queryResponse?.error ||
+      (typeof queryResponse?.message === 'string'
+        ? queryResponse.message
+        : undefined) ||
+      queryResponse?.statusText;
 
     // if datasource is still loading, don't render JS errors
     if (

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -391,9 +391,10 @@ export function handleChartDataResponse(response, json, useLegacyApi) {
         }
         return waitForAsyncData(result);
       default:
-        throw new Error(
-          `Received unexpected response status (${response.status}) while fetching chart data`,
-        );
+        // throw new Error(
+        //   `Received unexpected response status (${response.status}) while fetching chart data`,
+        // );
+        return Promise.reject(response);
     }
   }
   return json.result;

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -117,13 +117,13 @@ export default function chartReducer(
         // chartAlert: action.queriesResponse
         //   ? action.queriesResponse?.[0]?.error
         //   : t('Network error.'),
-        chartAlert: chartAlert,
+        chartAlert,
         chartUpdateEndTime: now(),
         queriesResponse: action.queriesResponse,
         // chartStackTrace: action.queriesResponse
         //   ? action.queriesResponse?.[0]?.stacktrace
         //   : null,
-        chartStackTrace: chartStackTrace,
+        chartStackTrace,
       };
     },
     [actions.DYNAMIC_PLUGIN_CONTROLS_READY](state) {

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -100,17 +100,29 @@ export default function chartReducer(
       };
     },
     [actions.CHART_UPDATE_FAILED](state) {
+      const queryResponse = action.queriesResponse?.[0];
+      const chartAlert =
+        queryResponse?.errors?.[0]?.message ||
+        queryResponse?.error ||
+        (typeof queryResponse?.message === 'string'
+          ? queryResponse.message
+          : undefined) ||
+        queryResponse?.statusText || t('Network error.');
+      const chartStackTrace = queryResponse?.stacktrace || null;
+
       return {
         ...state,
         chartStatus: 'failed',
-        chartAlert: action.queriesResponse
-          ? action.queriesResponse?.[0]?.error
-          : t('Network error.'),
+        // chartAlert: action.queriesResponse
+        //   ? action.queriesResponse?.[0]?.error
+        //   : t('Network error.'),
+        chartAlert: chartAlert,
         chartUpdateEndTime: now(),
         queriesResponse: action.queriesResponse,
-        chartStackTrace: action.queriesResponse
-          ? action.queriesResponse?.[0]?.stacktrace
-          : null,
+        // chartStackTrace: action.queriesResponse
+        //   ? action.queriesResponse?.[0]?.stacktrace
+        //   : null,
+        chartStackTrace: chartStackTrace,
       };
     },
     [actions.DYNAMIC_PLUGIN_CONTROLS_READY](state) {

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -107,7 +107,8 @@ export default function chartReducer(
         (typeof queryResponse?.message === 'string'
           ? queryResponse.message
           : undefined) ||
-        queryResponse?.statusText || t('Network error.');
+        queryResponse?.statusText ||
+        t('Network error.');
       const chartStackTrace = queryResponse?.stacktrace || null;
 
       return {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Preserve error messages returned by the backend when the network response is `500`. We're seeing intermittent "Data error: {}" when loading charts and losing the context of the error.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
#### Before:
<img width="1445" height="515" alt="Screenshot 2026-04-14 at 9 28 20 PM" src="https://github.com/user-attachments/assets/d4ea4aae-b1b8-4650-bee7-f83a305a8a72" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- **_unable to reproduce the intermittent MySQL failures while on dev environment, I'll need to push changes to staging..._** 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
