### PR TITLE
feat(governance): Add filter config for is_tier1_candidate filter

### DIFF
--- a/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
@@ -4,8 +4,15 @@
  */
 import { Filter } from 'src/components/ListView/types';
 
+export interface DashboardListSearchFilterOptions {
+  /** Show the Tier 1 Candidate filter (requires can_promote_tier_1 permission). */
+  canPromoteTier1?: boolean;
+}
+
 /** Extra search filters to add to the dashboard list (e.g. tier, nimbus_project). */
-export function getDashboardListSearchFilters(): Filter[] {
+export function getDashboardListSearchFilters(
+  _options: DashboardListSearchFilterOptions = {},
+): Filter[] {
   return [];
 }
 

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -129,4 +129,6 @@ export enum FilterOperator {
   Tier = 'tier',
   /** Governance: filter by Nimbus project */
   NimbusProject = 'nimbus_project',
+  /** Governance: filter by tier 1 candidate status */
+  DashboardIsTier1Candidate = 'dashboard_is_tier1_candidate',
 }

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -159,6 +159,11 @@ function DashboardList(props: DashboardListProps) {
     state => state.user,
   );
   const canReadTag = findPermission('can_read', 'Tag', roles);
+  const canPromoteTier1 = findPermission(
+    'can_promote_tier_1',
+    'DashboardGovernanceRestApi',
+    roles,
+  );
 
   const reduxUser = useSelector<any, UserWithPermissionsAndRoles>(
     state => state.user,
@@ -640,10 +645,12 @@ function DashboardList(props: DashboardListProps) {
         ),
         paginate: true,
       },
-      ...(showGovernanceExtras ? getDashboardListSearchFilters() : []),
+      ...(showGovernanceExtras
+        ? getDashboardListSearchFilters({ canPromoteTier1 })
+        : []),
     ] as Filters;
     return filters_list;
-  }, [addDangerToast, favoritesFilter, props.user, showGovernanceExtras]);
+  }, [addDangerToast, canPromoteTier1, favoritesFilter, props.user, showGovernanceExtras]);
 
   const sortTypes = [
     {

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -650,7 +650,13 @@ function DashboardList(props: DashboardListProps) {
         : []),
     ] as Filters;
     return filters_list;
-  }, [addDangerToast, canPromoteTier1, favoritesFilter, props.user, showGovernanceExtras]);
+  }, [
+    addDangerToast,
+    canPromoteTier1,
+    favoritesFilter,
+    props.user,
+    showGovernanceExtras,
+  ]);
 
   const sortTypes = [
     {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set up types for new tier 1 candidate filter & pass can_promote_tier1 permission to getDashboardListSearchFilters (to determine when to render filter).

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
