### PR TITLE
feat(governance): Update UI to surface soft deletion of charts/dashboards

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -62,6 +62,22 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestPushToDataHubModal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestPushToDataHubModal.stub.tsx',
+    '^@pinterest-plugins/src/explore/pinterestExploreViewContainer$':
+      '<rootDir>/pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx',
+    '^@pinterest-plugins/src/dashboard/pinterestDashboardPage$':
+      '<rootDir>/pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx',
+    '^@pinterest-plugins/src/features/dashboards/pinterestDashboardCard$':
+      '<rootDir>/pinterest-plugins/src/features/dashboards/pinterestDashboardCard.stub.tsx',
+    '^@pinterest-plugins/src/features/charts/pinterestChartCard$':
+      '<rootDir>/pinterest-plugins/src/features/charts/pinterestChartCard.stub.tsx',
+    '^@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell$':
+      '<rootDir>/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx',
+    '^@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay$':
+      '<rootDir>/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx',
+    '^@pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter$':
+      '<rootDir>/pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter.stub.ts',
+    '^@pinterest-plugins/src/components/Chart/pinterestChartContainer$':
+      '<rootDir>/pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx
@@ -1,0 +1,6 @@
+/**
+ * Stub for ``pinterestChartContainer``. In non-plugin builds the soft-deletion
+ * concept does not exist, so this is a thin pass-through to the upstream
+ * ``ChartContainer``.
+ */
+export { default } from 'src/components/Chart/ChartContainer';

--- a/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx
@@ -3,7 +3,6 @@
  * concept does not exist, so this is a thin pass-through to the upstream
  * ``DashboardPage`` that preserves the same prop shape.
  */
-import React from 'react';
 import { DashboardPage } from 'src/dashboard/containers/DashboardPage';
 
 export type PinterestDashboardPageProps = {

--- a/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx
@@ -1,0 +1,17 @@
+/**
+ * Stub for ``PinterestDashboardPage``. In non-plugin builds the soft-deletion
+ * concept does not exist, so this is a thin pass-through to the upstream
+ * ``DashboardPage`` that preserves the same prop shape.
+ */
+import React from 'react';
+import { DashboardPage } from 'src/dashboard/containers/DashboardPage';
+
+export type PinterestDashboardPageProps = {
+  idOrSlug: string;
+};
+
+const PinterestDashboardPage = ({ idOrSlug }: PinterestDashboardPageProps) => (
+  <DashboardPage idOrSlug={idOrSlug} />
+);
+
+export default PinterestDashboardPage;

--- a/superset-frontend/pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx
@@ -1,0 +1,11 @@
+/**
+ * Stub for ``PinterestExploreViewContainer``. In non-plugin builds the
+ * soft-deletion concept does not exist, so this is a thin pass-through to the
+ * upstream ``ExploreViewContainer``.
+ */
+import React from 'react';
+import ExploreViewContainer from 'src/explore/components/ExploreViewContainer';
+
+const PinterestExploreViewContainer = () => <ExploreViewContainer />;
+
+export default PinterestExploreViewContainer;

--- a/superset-frontend/pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx
@@ -3,7 +3,6 @@
  * soft-deletion concept does not exist, so this is a thin pass-through to the
  * upstream ``ExploreViewContainer``.
  */
-import React from 'react';
 import ExploreViewContainer from 'src/explore/components/ExploreViewContainer';
 
 const PinterestExploreViewContainer = () => <ExploreViewContainer />;

--- a/superset-frontend/pinterest-plugins/src/features/charts/pinterestChartCard.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/charts/pinterestChartCard.stub.tsx
@@ -1,0 +1,8 @@
+/**
+ * Stub for ``PinterestChartCard``. In non-plugin builds the soft-deletion
+ * concept does not exist, so this is a thin pass-through to the upstream
+ * ``ChartCard``.
+ */
+import ChartCard from 'src/features/charts/ChartCard';
+
+export default ChartCard;

--- a/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
@@ -11,6 +11,7 @@ export interface DashboardListSearchFilterOptions {
 
 /** Extra search filters to add to the dashboard list (e.g. tier, nimbus_project). */
 export function getDashboardListSearchFilters(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: DashboardListSearchFilterOptions = {},
 ): Filter[] {
   return [];
@@ -22,6 +23,7 @@ export type DashboardListExtraColumnsOptions = {
 
 /** Extra column names to request from the dashboard list API (e.g. tier, nimbus_project). */
 export function getDashboardListExtraColumnsToFetch(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: DashboardListExtraColumnsOptions = {},
 ): string[] {
   return [];

--- a/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/dashboards/dashboardListExtensions.stub.tsx
@@ -16,8 +16,14 @@ export function getDashboardListSearchFilters(
   return [];
 }
 
+export type DashboardListExtraColumnsOptions = {
+  includeGovernance?: boolean;
+};
+
 /** Extra column names to request from the dashboard list API (e.g. tier, nimbus_project). */
-export function getDashboardListExtraColumnsToFetch(): string[] {
+export function getDashboardListExtraColumnsToFetch(
+  _options: DashboardListExtraColumnsOptions = {},
+): string[] {
   return [];
 }
 

--- a/superset-frontend/pinterest-plugins/src/features/dashboards/pinterestDashboardCard.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/dashboards/pinterestDashboardCard.stub.tsx
@@ -1,0 +1,8 @@
+/**
+ * Stub for ``PinterestDashboardCard``. In non-plugin builds the soft-deletion
+ * concept does not exist, so this is a thin pass-through to the upstream
+ * ``DashboardCard``.
+ */
+import DashboardCard from 'src/features/dashboards/DashboardCard';
+
+export default DashboardCard;

--- a/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx
@@ -3,7 +3,7 @@
  * soft-deletion concept does not exist, so this is a thin pass-through that
  * renders ``children`` unchanged.
  */
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 export type PinterestSoftDeletedCardOverlayProps = {
   resource: 'dashboard' | 'chart';

--- a/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx
@@ -1,0 +1,19 @@
+/**
+ * Stub for ``PinterestSoftDeletedCardOverlay``. In non-plugin builds the
+ * soft-deletion concept does not exist, so this is a thin pass-through that
+ * renders ``children`` unchanged.
+ */
+import React, { ReactNode } from 'react';
+
+export type PinterestSoftDeletedCardOverlayProps = {
+  resource: 'dashboard' | 'chart';
+  owners?: unknown[];
+  dataTest?: string;
+  children: ReactNode;
+};
+
+const PinterestSoftDeletedCardOverlay = ({
+  children,
+}: PinterestSoftDeletedCardOverlayProps) => <>{children}</>;
+
+export default PinterestSoftDeletedCardOverlay;

--- a/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx
@@ -1,0 +1,23 @@
+/**
+ * Stub for ``PinterestSoftDeletedCell``. In non-plugin builds the
+ * soft-deletion concept does not exist, so this is a thin pass-through that
+ * renders ``children`` unchanged.
+ */
+import React, { ReactNode } from 'react';
+
+type SoftDeletableEntity = {
+  deleted_on?: string | null;
+};
+
+export type PinterestSoftDeletedCellProps = {
+  resource: 'dashboard' | 'chart';
+  entity: SoftDeletableEntity;
+  variant?: 'name' | 'actions';
+  children: ReactNode;
+};
+
+const PinterestSoftDeletedCell = ({
+  children,
+}: PinterestSoftDeletedCellProps) => <>{children}</>;
+
+export default PinterestSoftDeletedCell;

--- a/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx
@@ -3,7 +3,7 @@
  * soft-deletion concept does not exist, so this is a thin pass-through that
  * renders ``children`` unchanged.
  */
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 type SoftDeletableEntity = {
   deleted_on?: string | null;

--- a/superset-frontend/pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter.stub.ts
+++ b/superset-frontend/pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter.stub.ts
@@ -1,0 +1,8 @@
+/**
+ * Stub for ``softDeletionSliceFilter``. In non-plugin builds the soft-deletion
+ * concept does not exist, so this is a pass-through that leaves the slice list
+ * unchanged.
+ */
+export function filterSoftDeletedSlices<T>(slices: T[]): T[] {
+  return slices;
+}

--- a/superset-frontend/src/dashboard/actions/hydrate.js
+++ b/superset-frontend/src/dashboard/actions/hydrate.js
@@ -123,6 +123,8 @@ export const hydrateDashboard =
         owners: slice.owners,
         modified: slice.modified,
         changed_on: new Date(slice.changed_on).getTime(),
+        // Pinterest: ISO timestamp set when the chart is soft-deleted.
+        deleted_on: slice.deleted_on,
       };
 
       sliceIds.add(key);

--- a/superset-frontend/src/dashboard/actions/sliceEntities.ts
+++ b/superset-frontend/src/dashboard/actions/sliceEntities.ts
@@ -86,6 +86,8 @@ const parseResult = (result: any[]) =>
         thumbnail_url: slice.thumbnail_url,
         owners: slice.owners,
         created_by: slice.created_by,
+        // Pinterest: ISO timestamp set when the chart is soft-deleted.
+        deleted_on: slice.deleted_on,
       },
     };
   }, {});
@@ -135,6 +137,7 @@ export function fetchSlices(
           'viz_type',
           'owners.id',
           'created_by.id',
+          'deleted_on',
         ],
         filters,
         page_size: FETCH_SLICES_PAGE_SIZE,

--- a/superset-frontend/src/dashboard/components/SliceAdder.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.tsx
@@ -46,6 +46,8 @@ import Checkbox from 'src/components/Checkbox';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Dispatch } from 'redux';
 import { Slice } from 'src/dashboard/types';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
 import { filterSoftDeletedSlices } from '@pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter';
 import AddSliceCard from './AddSliceCard';
 import AddSliceDragPreview from './dnd/AddSliceDragPreview';
@@ -229,11 +231,12 @@ class SliceAdder extends Component<SliceAdderProps, SliceAdderState> {
     sortBy: keyof Slice,
     showOnlyMyCharts: boolean,
   ) {
-    return filterSoftDeletedSlices(Object.values(slices))
-      .filter(slice =>
+    return filterSoftDeletedSlices<Slice>(Object.values(slices))
+      .filter((slice: Slice) =>
         showOnlyMyCharts
-          ? slice?.owners?.find(owner => owner.id === this.props.userId) ||
-            slice?.created_by?.id === this.props.userId
+          ? slice?.owners?.find(
+              (owner: { id: number }) => owner.id === this.props.userId,
+            ) || slice?.created_by?.id === this.props.userId
           : true,
       )
       .filter(createFilter(searchTerm, KEYS_TO_FILTERS))

--- a/superset-frontend/src/dashboard/components/SliceAdder.tsx
+++ b/superset-frontend/src/dashboard/components/SliceAdder.tsx
@@ -46,6 +46,7 @@ import Checkbox from 'src/components/Checkbox';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
 import { Dispatch } from 'redux';
 import { Slice } from 'src/dashboard/types';
+import { filterSoftDeletedSlices } from '@pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter';
 import AddSliceCard from './AddSliceCard';
 import AddSliceDragPreview from './dnd/AddSliceDragPreview';
 import { DragDroppable } from './dnd/DragDroppable';
@@ -228,7 +229,7 @@ class SliceAdder extends Component<SliceAdderProps, SliceAdderState> {
     sortBy: keyof Slice,
     showOnlyMyCharts: boolean,
   ) {
-    return Object.values(slices)
+    return filterSoftDeletedSlices(Object.values(slices))
       .filter(slice =>
         showOnlyMyCharts
           ? slice?.owners?.find(owner => owner.id === this.props.userId) ||

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -26,6 +26,8 @@ import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { exportChart, mountExploreUrl } from 'src/explore/exploreUtils';
+// import ChartContainer from 'src/components/Chart/ChartContainer';
+// eslint-disable-next-line import/no-unresolved
 import ChartContainer from '@pinterest-plugins/src/components/Chart/pinterestChartContainer';
 import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,

--- a/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Chart.jsx
@@ -26,7 +26,7 @@ import { bindActionCreators } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { exportChart, mountExploreUrl } from 'src/explore/exploreUtils';
-import ChartContainer from 'src/components/Chart/ChartContainer';
+import ChartContainer from '@pinterest-plugins/src/components/Chart/pinterestChartContainer';
 import {
   LOG_ACTIONS_CHANGE_DASHBOARD_FILTER,
   LOG_ACTIONS_EXPLORE_DASHBOARD_CHART,

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -146,6 +146,7 @@ export type DashboardInfo = {
   changed_by?: Owner;
   created_by?: Owner;
   owners: Owner[];
+  deleted_on?: string | null;
 };
 
 export type ChartsState = { [key: string]: Chart };
@@ -252,6 +253,7 @@ export type Slice = {
   datasource_name: string;
   owners: { id: number }[];
   created_by: { id: number };
+  deleted_on?: string | null;
 };
 
 export enum MenuKeys {

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -40,7 +40,8 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import Loading from 'src/components/Loading';
 import DeleteModal from 'src/components/DeleteModal';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
-import DashboardCard from 'src/features/dashboards/DashboardCard';
+// eslint-disable-next-line import/no-unresolved
+import DashboardCard from '@pinterest-plugins/src/features/dashboards/pinterestDashboardCard';
 import EmptyState from './EmptyState';
 import SubMenu from './SubMenu';
 import { WelcomeTable } from './types';

--- a/superset-frontend/src/features/home/DashboardTable.tsx
+++ b/superset-frontend/src/features/home/DashboardTable.tsx
@@ -40,6 +40,8 @@ import withToasts from 'src/components/MessageToasts/withToasts';
 import Loading from 'src/components/Loading';
 import DeleteModal from 'src/components/DeleteModal';
 import PropertiesModal from 'src/dashboard/components/PropertiesModal';
+// import DashboardCard from 'src/features/dashboards/DashboardCard';
+// @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import DashboardCard from '@pinterest-plugins/src/features/dashboards/pinterestDashboardCard';
 import EmptyState from './EmptyState';
@@ -280,7 +282,9 @@ function DashboardTable({
               saveFavoriteStatus={saveFavoriteStatus}
               favoriteStatus={favoriteStatus[e.id]}
               handleBulkDashboardExport={handleBulkDashboardExport}
-              onDelete={dashboard => setDashboardToDelete(dashboard)}
+              onDelete={(dashboard: Dashboard) =>
+                setDashboardToDelete(dashboard)
+              }
             />
           ))}
         </CardContainer>

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -36,6 +36,7 @@ import getFormDataWithExtraFilters from 'src/dashboard/util/charts/getFormDataWi
 import { getAppliedFilterValues } from 'src/dashboard/util/activeDashboardFilters';
 import { getParsedExploreURLParams } from 'src/explore/exploreUtils/getParsedExploreURLParams';
 import { hydrateExplore } from 'src/explore/actions/hydrateExplore';
+// import ExploreViewContainer from 'src/explore/components/ExploreViewContainer';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import ExploreViewContainer from '@pinterest-plugins/src/explore/pinterestExploreViewContainer';

--- a/superset-frontend/src/pages/Chart/index.tsx
+++ b/superset-frontend/src/pages/Chart/index.tsx
@@ -36,7 +36,9 @@ import getFormDataWithExtraFilters from 'src/dashboard/util/charts/getFormDataWi
 import { getAppliedFilterValues } from 'src/dashboard/util/activeDashboardFilters';
 import { getParsedExploreURLParams } from 'src/explore/exploreUtils/getParsedExploreURLParams';
 import { hydrateExplore } from 'src/explore/actions/hydrateExplore';
-import ExploreViewContainer from 'src/explore/components/ExploreViewContainer';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import ExploreViewContainer from '@pinterest-plugins/src/explore/pinterestExploreViewContainer';
 import { ExploreResponsePayload, SaveActionType } from 'src/explore/types';
 import { fallbackExploreInitialData } from 'src/explore/fixtures';
 import { getItem, LocalStorageKeys } from 'src/utils/localStorageHelpers';

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -67,6 +67,7 @@ import CertifiedBadge from 'src/components/CertifiedBadge';
 import { GenericLink } from 'src/components/GenericLink/GenericLink';
 import { loadTags } from 'src/components/Tags/utils';
 import FacePile from 'src/components/FacePile';
+// import ChartCard from 'src/features/charts/ChartCard';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import ChartCard from '@pinterest-plugins/src/features/charts/pinterestChartCard';

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -67,12 +67,17 @@ import CertifiedBadge from 'src/components/CertifiedBadge';
 import { GenericLink } from 'src/components/GenericLink/GenericLink';
 import { loadTags } from 'src/components/Tags/utils';
 import FacePile from 'src/components/FacePile';
-import ChartCard from 'src/features/charts/ChartCard';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import ChartCard from '@pinterest-plugins/src/features/charts/pinterestChartCard';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { findPermission } from 'src/utils/findPermission';
 import { DashboardCrossLinks } from 'src/components/ListView/DashboardCrossLinks';
 import { ModifiedInfo } from 'src/components/AuditInfo';
 import { QueryObjectColumns } from 'src/views/CRUD/types';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestSoftDeletedCell from '@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -332,18 +337,15 @@ function ChartList(props: ChartListProps) {
         hidden: !userId,
       },
       {
-        Cell: ({
-          row: {
-            original: {
-              url,
-              slice_name: sliceName,
-              certified_by: certifiedBy,
-              certification_details: certificationDetails,
-              description,
-            },
-          },
-        }: any) => (
-          <FlexRowContainer>
+        Cell: ({ row: { original } }: any) => {
+          const {
+            url,
+            slice_name: sliceName,
+            certified_by: certifiedBy,
+            certification_details: certificationDetails,
+            description,
+          } = original;
+          const link = (
             <Link to={url} data-test={`${sliceName}-list-chart-title`}>
               {certifiedBy && (
                 <>
@@ -355,9 +357,20 @@ function ChartList(props: ChartListProps) {
               )}
               {sliceName}
             </Link>
-            {description && <InfoTooltip tooltip={description} />}
-          </FlexRowContainer>
-        ),
+          );
+          return (
+            <FlexRowContainer>
+              <PinterestSoftDeletedCell
+                resource="chart"
+                entity={original}
+                variant="name"
+              >
+                {link}
+              </PinterestSoftDeletedCell>
+              {description && <InfoTooltip tooltip={description} />}
+            </FlexRowContainer>
+          );
+        },
         Header: t('Name'),
         accessor: 'slice_name',
       },
@@ -460,7 +473,7 @@ function ChartList(props: ChartListProps) {
             return null;
           }
 
-          return (
+          const actions = (
             <StyledActions className="actions">
               {canDelete && (
                 <ConfirmStatusChange
@@ -525,6 +538,16 @@ function ChartList(props: ChartListProps) {
                 </Tooltip>
               )}
             </StyledActions>
+          );
+
+          return (
+            <PinterestSoftDeletedCell
+              resource="chart"
+              entity={original}
+              variant="actions"
+            >
+              {actions}
+            </PinterestSoftDeletedCell>
           );
         },
         Header: t('Actions'),

--- a/superset-frontend/src/pages/Dashboard/index.tsx
+++ b/superset-frontend/src/pages/Dashboard/index.tsx
@@ -18,6 +18,7 @@
  */
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
+// import { DashboardPage } from 'src/dashboard/containers/DashboardPage';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestDashboardPage from '@pinterest-plugins/src/dashboard/pinterestDashboardPage';

--- a/superset-frontend/src/pages/Dashboard/index.tsx
+++ b/superset-frontend/src/pages/Dashboard/index.tsx
@@ -18,11 +18,13 @@
  */
 import { FC } from 'react';
 import { useParams } from 'react-router-dom';
-import { DashboardPage } from 'src/dashboard/containers/DashboardPage';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestDashboardPage from '@pinterest-plugins/src/dashboard/pinterestDashboardPage';
 
 const DashboardRoute: FC = () => {
   const { idOrSlug } = useParams<{ idOrSlug: string }>();
-  return <DashboardPage idOrSlug={idOrSlug} />;
+  return <PinterestDashboardPage idOrSlug={idOrSlug} />;
 };
 
 export default DashboardRoute;

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -64,7 +64,9 @@ import {
 } from 'src/views/CRUD/types';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import { loadTags } from 'src/components/Tags/utils';
-import DashboardCard from 'src/features/dashboards/DashboardCard';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import DashboardCard from '@pinterest-plugins/src/features/dashboards/pinterestDashboardCard';
 import { DashboardStatus } from 'src/features/dashboards/types';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import { findPermission } from 'src/utils/findPermission';
@@ -73,6 +75,9 @@ import { ModifiedInfo } from 'src/components/AuditInfo';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestNewDashboardTierModal from '@pinterest-plugins/src/governance/pinterestNewDashboardTierModal';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestSoftDeletedCell from '@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell';
 import {
   getDashboardListExtraColumnsToFetch,
   getDashboardListExtraListColumns,
@@ -128,6 +133,10 @@ const Actions = styled.div`
   color: ${({ theme }) => theme.colors.grayscale.base};
 `;
 
+// Base list columns shared with upstream Superset. Plugin-owned extras (tier,
+// nimbus_project, deleted_on, owners.username, ...) live in
+// `getDashboardListExtraColumnsToFetch` so new ones can be added from the
+// plugin without editing this file.
 const DASHBOARD_COLUMNS_TO_FETCH = [
   'id',
   'dashboard_title',
@@ -193,9 +202,14 @@ function DashboardList(props: DashboardListProps) {
     undefined,
     undefined,
     undefined,
+    // Always-on extras (e.g. soft-deletion columns) are fetched for every
+    // user; governance-only display columns are gated on `showGovernanceExtras`
+    // and folded in by the same helper.
     [
       ...DASHBOARD_COLUMNS_TO_FETCH,
-      ...(showGovernanceExtras ? getDashboardListExtraColumnsToFetch() : []),
+      ...getDashboardListExtraColumnsToFetch({
+        includeGovernance: showGovernanceExtras,
+      }),
     ],
   );
   const dashboardIds = useMemo(() => dashboards.map(d => d.id), [dashboards]);
@@ -350,28 +364,36 @@ function DashboardList(props: DashboardListProps) {
         hidden: !user?.userId,
       },
       {
-        Cell: ({
-          row: {
-            original: {
-              url,
-              dashboard_title: dashboardTitle,
-              certified_by: certifiedBy,
-              certification_details: certificationDetails,
-            },
-          },
-        }: any) => (
-          <Link to={url}>
-            {certifiedBy && (
-              <>
-                <CertifiedBadge
-                  certifiedBy={certifiedBy}
-                  details={certificationDetails}
-                />{' '}
-              </>
-            )}
-            {dashboardTitle}
-          </Link>
-        ),
+        Cell: ({ row: { original } }: any) => {
+          const {
+            url,
+            dashboard_title: dashboardTitle,
+            certified_by: certifiedBy,
+            certification_details: certificationDetails,
+          } = original;
+          const link = (
+            <Link to={url}>
+              {certifiedBy && (
+                <>
+                  <CertifiedBadge
+                    certifiedBy={certifiedBy}
+                    details={certificationDetails}
+                  />{' '}
+                </>
+              )}
+              {dashboardTitle}
+            </Link>
+          );
+          return (
+            <PinterestSoftDeletedCell
+              resource="dashboard"
+              entity={original}
+              variant="name"
+            >
+              {link}
+            </PinterestSoftDeletedCell>
+          );
+        },
         Header: t('Name'),
         accessor: 'dashboard_title',
       },
@@ -449,7 +471,7 @@ function DashboardList(props: DashboardListProps) {
           const handleEdit = () => openDashboardEditModal(original);
           const handleExport = () => handleBulkDashboardExport([original]);
 
-          return (
+          const actions = (
             <Actions className="actions">
               {canDelete && (
                 <ConfirmStatusChange
@@ -513,6 +535,16 @@ function DashboardList(props: DashboardListProps) {
                 </Tooltip>
               )}
             </Actions>
+          );
+
+          return (
+            <PinterestSoftDeletedCell
+              resource="dashboard"
+              entity={original}
+              variant="actions"
+            >
+              {actions}
+            </PinterestSoftDeletedCell>
           );
         },
         Header: t('Actions'),

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -64,6 +64,7 @@ import {
 } from 'src/views/CRUD/types';
 import CertifiedBadge from 'src/components/CertifiedBadge';
 import { loadTags } from 'src/components/Tags/utils';
+// import DashboardCard from 'src/features/dashboards/DashboardCard';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import DashboardCard from '@pinterest-plugins/src/features/dashboards/pinterestDashboardCard';
@@ -567,6 +568,7 @@ function DashboardList(props: DashboardListProps) {
       refreshData,
       addSuccessToast,
       addDangerToast,
+      showGovernanceExtras,
     ],
   );
 
@@ -728,7 +730,7 @@ function DashboardList(props: DashboardListProps) {
         saveFavoriteStatus={saveFavoriteStatus}
         favoriteStatus={favoriteStatus[dashboard.id]}
         handleBulkDashboardExport={handleBulkDashboardExport}
-        onDelete={dashboard => setDashboardToDelete(dashboard)}
+        onDelete={(dashboard: CRUDDashboard) => setDashboardToDelete(dashboard)}
       />
     ),
     [

--- a/superset-frontend/src/pinterest/welcome/DashboardContainer.tsx
+++ b/superset-frontend/src/pinterest/welcome/DashboardContainer.tsx
@@ -9,6 +9,12 @@ import { styled, t } from '@superset-ui/core';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import ListViewCard from 'src/components/ListViewCard';
 import FaveStar from 'src/components/FaveStar';
+// eslint-disable-next-line import/no-unresolved
+import PinterestSoftDeletedCardOverlay from '@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay';
+import {
+  // eslint-disable-next-line import/no-unresolved
+  SoftDeletionOwner,
+} from '@pinterest-plugins/src/governance/softDeletion/content';
 
 type DashboardContainerProps = {
   dashboards: Dashboard[];
@@ -39,13 +45,8 @@ export default function DashboardContainer({
   return dashboards.length ? (
     <Styles>
       <CardContainer showThumbnails={showThumbnails} className="card-container">
-        {dashboards.map(d => (
-          <CardStyles
-            onClick={() => {
-              history.push(d.url);
-            }}
-            key={d.id}
-          >
+        {dashboards.map(d => {
+          const card = (
             <ListViewCard
               loading={d.loading || false}
               title={d.dashboard_title}
@@ -76,8 +77,37 @@ export default function DashboardContainer({
                 </ListViewCard.Actions>
               }
             />
-          </CardStyles>
-        ))}
+          );
+
+          // When the dashboard is soft-deleted: skip the navigation onClick and
+          // wrap the card in the shared soft-deletion overlay. The overlay
+          // disables pointer events on the inner card, so favorite/links are
+          // also neutralised - matching the list/page-level treatment.
+          if (d.deleted_on) {
+            return (
+              <CardStyles key={d.id}>
+                <PinterestSoftDeletedCardOverlay
+                  resource="dashboard"
+                  owners={(d.owners ?? []) as SoftDeletionOwner[]}
+                  dataTest="homepage-dashboard-card-soft-deleted"
+                >
+                  {card}
+                </PinterestSoftDeletedCardOverlay>
+              </CardStyles>
+            );
+          }
+
+          return (
+            <CardStyles
+              onClick={() => {
+                history.push(d.url);
+              }}
+              key={d.id}
+            >
+              {card}
+            </CardStyles>
+          );
+        })}
       </CardContainer>
     </Styles>
   ) : (

--- a/superset-frontend/src/pinterest/welcome/DashboardContainer.tsx
+++ b/superset-frontend/src/pinterest/welcome/DashboardContainer.tsx
@@ -9,12 +9,12 @@ import { styled, t } from '@superset-ui/core';
 import { UserWithPermissionsAndRoles } from 'src/types/bootstrapTypes';
 import ListViewCard from 'src/components/ListViewCard';
 import FaveStar from 'src/components/FaveStar';
+// @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestSoftDeletedCardOverlay from '@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay';
-import {
-  // eslint-disable-next-line import/no-unresolved
-  SoftDeletionOwner,
-} from '@pinterest-plugins/src/governance/softDeletion/content';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { SoftDeletionOwner } from '@pinterest-plugins/src/governance/softDeletion/content';
 
 type DashboardContainerProps = {
   dashboards: Dashboard[];

--- a/superset-frontend/src/types/Chart.ts
+++ b/superset-frontend/src/types/Chart.ts
@@ -60,6 +60,8 @@ export interface Chart {
 
   // TODO: Update API spec to describe `dashboards` key
   dashboards: ChartLinkedDashboard[];
+  /** Pinterest: ISO timestamp set when the chart is soft-deleted. */
+  deleted_on?: string | null;
 }
 
 export type Slice = {

--- a/superset-frontend/src/views/CRUD/types.ts
+++ b/superset-frontend/src/views/CRUD/types.ts
@@ -69,6 +69,8 @@ export interface Dashboard {
   thumbnail_url: string;
   owners: Owner[];
   loading?: boolean;
+  /** Pinterest: ISO timestamp set when the dashboard is soft-deleted. */
+  deleted_on?: string | null;
 }
 
 export type SavedQueryObject = {

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -223,6 +223,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/explore\/pinterestExploreViewContainer$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/explore/pinterestExploreViewContainer.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/explore\/components\/warden\/createWardenAlertModal$/,
       path.resolve(
         __dirname,
@@ -255,6 +262,55 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       path.resolve(
         __dirname,
         'pinterest-plugins/src/governance/pinterestPushToDataHubModal.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/dashboard\/pinterestDashboardPage$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/dashboard/pinterestDashboardPage.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/features\/dashboards\/pinterestDashboardCard$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/features/dashboards/pinterestDashboardCard.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/features\/charts\/pinterestChartCard$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/features/charts/pinterestChartCard.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/softDeletion\/pinterestSoftDeletedCell$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/softDeletion\/pinterestSoftDeletedCardOverlay$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCardOverlay.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/softDeletion\/softDeletionSliceFilter$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter.stub.ts',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/components\/Chart\/pinterestChartContainer$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx',
       ),
     ),
   );


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

**Context**: Soft-deletion is wired purely via `@pinterest-plugins/*` import swaps + Webpack stub replacements. No upstream component logic changes.

**Changes**

- Plugin stubs (pass-throughs under `superset-frontend/pinterest-plugins/`)
  - New: `pinterestDashboardPage`, `pinterestExploreViewContainer`, `pinterestDashboardCard`, `pinterestChartCard`, `pinterestSoftDeletedCell`, `pinterestSoftDeletedCardOverlay`, `softDeletionSliceFilter` (no-op identity), `pinterestChartContainer` (re-export of upstream `ChartContainer`).
  - Updated: `dashboardListExtensions.stub` for the new `{ includeGovernance }` options arg.

-  `webpack.config.js`
    - 7 new `NormalModuleReplacementPlugin` rules (one per new stub above, except `dashboardListExtensions` which already had one).

-  One-line import swaps
    - `pages/Dashboard/index.tsx`, `pages/Chart/index.tsx`, `features/home/DashboardTable.tsx`.
    - `dashboard/components/gridComponents/Chart.jsx` (`ChartContainer` → `pinterestChartContainer`), so soft-deleted dashboard charts never dispatch `/chart/data`.

-  List pages (`pages/{Dashboard,Chart}List/index.tsx`)
    - Card import swap + `name`/`actions` cell renderers wrapped in `PinterestSoftDeletedCell`.
    - Dashboard list passes `{ includeGovernance: showGovernanceExtras }` to the column helper.

-  `pinterest/welcome/DashboardContainer.tsx`
    - Wraps soft-deleted homepage cards in `PinterestSoftDeletedCardOverlay` and skips the navigation `onClick`.

-  Dashboard builder chart picker (`src/dashboard/`)
    - `actions/sliceEntities.ts`: adds `'deleted_on'` to `fetchSlices`' `columns` array and propagates it through `parseResult`.
    - `components/SliceAdder.tsx`: applies `filterSoftDeletedSlices` in `getFilteredSortedSlices` so soft-deleted charts can't be dragged onto dashboards.

-  Dashboard chart rendering (`src/dashboard/`)
    - `actions/hydrate.js`: adds `deleted_on: slice.deleted_on` to the `slices[key]` literal so the dashboard Redux slice carries the field from `/api/v1/dashboard/<id>/charts` into `pinterestChartContainer`'s guard.

-  Type augmentations (additive optional `deleted_on?: string | null`)
    - `dashboard/types.ts` — `DashboardInfo`, `Slice`.
    - `types/Chart.ts` — `Chart`.
    - `views/CRUD/types.ts` — `Dashboard`.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
Ran internally & tested various UIs

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
