### PR TITLE
feat(governance): Stub chart verification modal

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -44,6 +44,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestTieringInfoModal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestTieringInfoModal.stub.tsx',
+    '^@pinterest-plugins/src/governance/pinterestVerifyChartModal$':
+      '<rootDir>/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestPromoteTier1Modal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestPromoteTier1Modal.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestNewDashboardTierModal$':

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -80,6 +80,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestVerifyChartModal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
+    '^@pinterest-plugins/src/governance/chartGovernancePermissions$':
+      '<rootDir>/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -44,8 +44,6 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/explore/components/pinterestChartPills.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestTieringInfoModal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestTieringInfoModal.stub.tsx',
-    '^@pinterest-plugins/src/governance/pinterestVerifyChartModal$':
-      '<rootDir>/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestPromoteTier1Modal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestPromoteTier1Modal.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestNewDashboardTierModal$':
@@ -80,6 +78,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/governance/softDeletion/softDeletionSliceFilter.stub.ts',
     '^@pinterest-plugins/src/components/Chart/pinterestChartContainer$':
       '<rootDir>/pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx',
+    '^@pinterest-plugins/src/governance/pinterestVerifyChartModal$':
+      '<rootDir>/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -49,6 +49,7 @@ export enum FeatureFlag {
   HorizontalFilterBar = 'HORIZONTAL_FILTER_BAR',
   ListviewsDefaultCardView = 'LISTVIEWS_DEFAULT_CARD_VIEW',
   PinterestDashboardGovernanceUi = 'PINTEREST_DASHBOARD_GOVERNANCE_UI',
+  PinterestChartGovernanceUi = 'PINTEREST_CHART_GOVERNANCE_UI',
   ScheduledQueries = 'SCHEDULED_QUERIES',
   SqllabBackendPersistence = 'SQLLAB_BACKEND_PERSISTENCE',
   SqlValidatorsByEngine = 'SQL_VALIDATORS_BY_ENGINE',

--- a/superset-frontend/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts
+++ b/superset-frontend/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts
@@ -1,0 +1,14 @@
+import type {
+    UndefinedUser,
+    UserWithPermissionsAndRoles,
+} from 'src/types/bootstrapTypes';
+
+/**
+ * Stubbed permission gate for OSS/submodule builds.
+ * Internal builds replace this with Pinterest role-aware logic.
+ */
+export function canVerifyChart(
+    _user?: UserWithPermissionsAndRoles | UndefinedUser | null,
+): boolean {
+    return false;
+}

--- a/superset-frontend/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts
+++ b/superset-frontend/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts
@@ -1,6 +1,6 @@
 import type {
-    UndefinedUser,
-    UserWithPermissionsAndRoles,
+  UndefinedUser,
+  UserWithPermissionsAndRoles,
 } from 'src/types/bootstrapTypes';
 
 /**
@@ -8,7 +8,7 @@ import type {
  * Internal builds replace this with Pinterest role-aware logic.
  */
 export function canVerifyChart(
-    _user?: UserWithPermissionsAndRoles | UndefinedUser | null,
+  _user?: UserWithPermissionsAndRoles | UndefinedUser | null,
 ): boolean {
-    return false;
+  return false;
 }

--- a/superset-frontend/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx
@@ -1,0 +1,20 @@
+import withToasts from '@superset-frontend/src/components/MessageToasts/withToasts';
+import {
+  UserWithPermissionsAndRoles,
+  UndefinedUser,
+} from '@superset-frontend/src/types/bootstrapTypes';
+
+type PinterestVerifyChartModalProps = {
+  sliceId: number;
+  show?: boolean;
+  onHide: () => void;
+  addSuccessToast: (message: string) => void;
+  addDangerToast: (message: string) => void;
+  user: UserWithPermissionsAndRoles | UndefinedUser;
+};
+
+const PinterestVerifyChartModal = (
+  _props: PinterestVerifyChartModalProps,
+) => <></>;
+
+export default withToasts(PinterestVerifyChartModal);

--- a/superset-frontend/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx
@@ -13,8 +13,8 @@ type PinterestVerifyChartModalProps = {
   user: UserWithPermissionsAndRoles | UndefinedUser;
 };
 
-const PinterestVerifyChartModal = (
-  _props: PinterestVerifyChartModalProps,
-) => <></>;
+const PinterestVerifyChartModal = (_props: PinterestVerifyChartModalProps) => (
+  <></>
+);
 
 export default withToasts(PinterestVerifyChartModal);

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -34,6 +34,9 @@ import { applyColors, resetColors } from 'src/utils/colorScheme';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import { getPinterestChartHeaderExtras } from '@pinterest-plugins/src/dashboard/pinterestChartHeaderExtras';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestVerifyChartModal from '@pinterest-plugins/src/governance/pinterestVerifyChartModal';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 import { useExploreMetadataBar } from './useExploreMetadataBar';
 
@@ -95,6 +98,7 @@ export const ExploreChartHeader = ({
   const dispatch = useDispatch();
   const { latestQueryFormData, sliceFormData } = chart;
   const [isPropertiesModalOpen, setIsPropertiesModalOpen] = useState(false);
+  const [isVerifyChartModalOpen, setIsVerifyChartModalOpen] = useState(false);
   const updateCategoricalNamespace = async () => {
     const { dashboards } = metadata || {};
     const dashboard =
@@ -137,6 +141,16 @@ export const ExploreChartHeader = ({
     setIsPropertiesModalOpen(false);
   };
 
+  const openVerifyChartModal = useCallback(() => {
+    if (slice?.slice_id != null) {
+      setIsVerifyChartModalOpen(true);
+    }
+  }, [slice?.slice_id]);
+
+  const closeVerifyChartModal = useCallback(() => {
+    setIsVerifyChartModalOpen(false);
+  }, []);
+
   const showModal = useCallback(() => {
     dispatch(setSaveChartModalVisibility(true));
   }, [dispatch]);
@@ -167,6 +181,7 @@ export const ExploreChartHeader = ({
       openPropertiesModal,
       ownState,
       metadata?.dashboards,
+      openVerifyChartModal,
     );
 
   const metadataBar = useExploreMetadataBar(metadata, slice);
@@ -251,6 +266,14 @@ export const ExploreChartHeader = ({
           onHide={closePropertiesModal}
           onSave={updateSlice}
           slice={slice}
+        />
+      )}
+      {isVerifyChartModalOpen && slice?.slice_id != null && (
+        <PinterestVerifyChartModal
+          sliceId={slice.slice_id}
+          show={isVerifyChartModalOpen}
+          onHide={closeVerifyChartModal}
+          user={user}
         />
       )}
     </>

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -45,6 +45,9 @@ import {
   LOG_ACTIONS_CHART_DOWNLOAD_AS_CSV_PIVOTED,
   LOG_ACTIONS_CHART_DOWNLOAD_AS_XLS,
 } from 'src/logger/LogUtils';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { canVerifyChart } from '@pinterest-plugins/src/governance/chartGovernancePermissions';
 import ViewQueryModal from '../controls/ViewQueryModal';
 import ViewTableInfoModal from '../controls/ViewTableInfoModal';
 import EmbedCodeContent from '../EmbedCodeContent';
@@ -71,6 +74,7 @@ const MENU_KEYS = {
   VIEW_QUERY: 'view_query',
   RUN_IN_SQL_LAB: 'run_in_sql_lab',
   VIEW_TABLE_INFO: 'view_table_info',
+  VERIFY: 'verify_chart',
 };
 
 const VIZ_TYPES_PIVOTABLE = [VizType.PivotTable];
@@ -125,6 +129,7 @@ export const useExploreAdditionalActionsMenu = (
   onOpenPropertiesModal,
   ownState,
   dashboards,
+  onOpenVerifyChartModal,
   ...rest
 ) => {
   const theme = useTheme();
@@ -135,6 +140,10 @@ export const useExploreAdditionalActionsMenu = (
   const chart = useSelector(
     state => state.charts?.[getChartKey(state.explore)],
   );
+  const user = useSelector(state => state.user);
+  const showVerifyChartAction =
+    isFeatureEnabled(FeatureFlag.PinterestChartGovernanceUi) &&
+    canVerifyChart(user);
 
   const { datasource } = latestQueryFormData;
 
@@ -290,6 +299,10 @@ export const useExploreAdditionalActionsMenu = (
           onOpenInEditor(latestQueryFormData, domEvent.metaKey);
           setIsDropdownVisible(false);
           break;
+        case MENU_KEYS.VERIFY:
+          onOpenVerifyChartModal();
+          setIsDropdownVisible(false);
+          break;
         default:
           break;
       }
@@ -304,6 +317,7 @@ export const useExploreAdditionalActionsMenu = (
       onOpenPropertiesModal,
       shareByEmail,
       slice?.slice_name,
+      onOpenVerifyChartModal,
     ],
   );
 
@@ -463,6 +477,11 @@ export const useExploreAdditionalActionsMenu = (
             {t('Run in SQL Lab')}
           </Menu.Item>
         )}
+        {showVerifyChartAction && (
+          <Menu.Item key={MENU_KEYS.VERIFY}>
+            {t('Verify Chart')}
+          </Menu.Item>
+        )}
       </Menu>
     ),
     [
@@ -474,6 +493,7 @@ export const useExploreAdditionalActionsMenu = (
       isDropdownVisible,
       latestQueryFormData,
       showReportSubMenu,
+      showVerifyChartAction,
       slice,
       theme.gridUnit,
     ],

--- a/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
+++ b/superset-frontend/src/explore/components/useExploreAdditionalActionsMenu/index.jsx
@@ -478,9 +478,7 @@ export const useExploreAdditionalActionsMenu = (
           </Menu.Item>
         )}
         {showVerifyChartAction && (
-          <Menu.Item key={MENU_KEYS.VERIFY}>
-            {t('Verify Chart')}
-          </Menu.Item>
+          <Menu.Item key={MENU_KEYS.VERIFY}>{t('Verify Chart')}</Menu.Item>
         )}
       </Menu>
     ),

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -195,13 +195,6 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
-      /@pinterest-plugins\/src\/governance\/pinterestVerifyChartModal$/,
-      path.resolve(
-        __dirname,
-        'pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
-      ),
-    ),
-    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/governance\/pinterestPromoteTier1Modal$/,
       path.resolve(
         __dirname,
@@ -318,6 +311,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       path.resolve(
         __dirname,
         'pinterest-plugins/src/components/Chart/pinterestChartContainer.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/pinterestVerifyChartModal$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
       ),
     ),
   );

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -195,6 +195,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/pinterestVerifyChartModal$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/governance\/pinterestPromoteTier1Modal$/,
       path.resolve(
         __dirname,

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -320,6 +320,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
         'pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
       ),
     ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/chartGovernancePermissions$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts',
+      ),
+    ),
   );
 }
 

--- a/superset/config.py
+++ b/superset/config.py
@@ -468,8 +468,8 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # [pinterest-specific]: Gate all dashboard governance UIs (tiering, promote, list
     # filters).
     "PINTEREST_DASHBOARD_GOVERNANCE_UI": False,
-    # [pinterest-specific]: Gate all chart governance UIs (verify, tiering, promote, list
-    # filters).
+    # [pinterest-specific]: Gate all chart governance UIs (verify, tiering,
+    # promote, list filters).
     "PINTEREST_CHART_GOVERNANCE_UI": False,
     # [pinterest-specific]: Allows embedding by dashboard id or slug
     "PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG": False,

--- a/superset/config.py
+++ b/superset/config.py
@@ -468,6 +468,9 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # [pinterest-specific]: Gate all dashboard governance UIs (tiering, promote, list
     # filters).
     "PINTEREST_DASHBOARD_GOVERNANCE_UI": False,
+    # [pinterest-specific]: Gate all chart governance UIs (verify, tiering, promote, list
+    # filters).
+    "PINTEREST_CHART_GOVERNANCE_UI": False,
     # [pinterest-specific]: Allows embedding by dashboard id or slug
     "PINTEREST_EMBEDDED_SUPERSET_BY_ID_OR_SLUG": False,
     # When using a recent version of Druid that supports JOINs turn this on


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds the plumbing for chart governance verification action in Explore. The chart action menu now supports a Verify Chart item gated behind the new `PINTEREST_CHART_GOVERNANCE_UI` feature flag and a `canVerifyChart` permission helper.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
