### PR TITLE
feat(plugins): add dashboard header & list page plugins

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -60,6 +60,10 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/sqllab/pinterestSqlLabToolbarExtras.stub.tsx',
     '^@pinterest-plugins/src/dashboard/pinterestChartHeaderExtras$':
       '<rootDir>/pinterest-plugins/src/dashboard/pinterestChartHeaderExtras.stub.tsx',
+    '^@pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras$':
+      '<rootDir>/pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx',
+    '^@pinterest-plugins/src/features/listView/pinterestListViewExtras$':
+      '<rootDir>/pinterest-plugins/src/features/listView/pinterestListViewExtras.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestPushToDataHubModal$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestPushToDataHubModal.stub.tsx',
     '^@pinterest-plugins/src/explore/pinterestExploreViewContainer$':

--- a/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx
@@ -1,3 +1,1 @@
-export const getPinterestDashboardHeaderExtras = (
-  _?: number | string,
-) => <></>;
+export const getPinterestDashboardHeaderExtras = (_?: number | string) => <></>;

--- a/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx
@@ -1,0 +1,3 @@
+export const getPinterestDashboardHeaderExtras = (
+  _?: number | string,
+) => <></>;

--- a/superset-frontend/pinterest-plugins/src/features/listView/pinterestListViewExtras.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/features/listView/pinterestListViewExtras.stub.tsx
@@ -1,0 +1,3 @@
+export const getPinterestDashboardListExtras = () => <></>;
+export const getPinterestChartListExtras = () => <></>;
+export const getPinterestDatasetListExtras = () => <></>;

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -72,6 +72,10 @@ import PinterestTitlePanelAdditionalItems from '@pinterest-plugins/src/governanc
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestDashboardBanners from '@pinterest-plugins/src/governance/pinterestDashboardBanners';
+
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestDashboardHeaderExtras } from '@pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras';
 import DashboardEmbedModal from '../EmbeddedModal';
 import OverwriteConfirm from '../OverwriteConfirm';
 import {
@@ -760,6 +764,7 @@ const Header = () => {
                 {t('Edit dashboard')}
               </Button>
             )}
+            {!isEmbedded && getPinterestDashboardHeaderExtras(dashboardInfo.id)}
           </div>
         )}
       </div>
@@ -769,12 +774,14 @@ const Header = () => {
       boundActionCreators.onRedo,
       boundActionCreators.onUndo,
       boundActionCreators.clearDashboardHistory,
+      dashboardInfo.id,
       editMode,
       emphasizeRedo,
       emphasizeUndo,
       handleCtrlY,
       handleCtrlZ,
       hasUnsavedChanges,
+      isEmbedded,
       overwriteDashboard,
       redoLength,
       toggleEditMode,

--- a/superset-frontend/src/features/home/SubMenu.tsx
+++ b/superset-frontend/src/features/home/SubMenu.tsx
@@ -147,6 +147,11 @@ export interface SubMenuProps {
   usesRouter?: boolean;
   color?: string;
   dropDownLinks?: Array<MenuObjectProps>;
+  /* Arbitrary nodes rendered in the right-aligned nav bar alongside `buttons`.
+   * Use this for trigger UI that doesn't fit the plain Button schema (e.g. a
+   * split button with dropdown, a Popover-anchored action). Rendered after
+   * the `buttons` array. */
+  extras?: ReactNode;
 }
 
 const { SubMenu } = MainNav;
@@ -278,6 +283,7 @@ const SubMenuComponent: FunctionComponent<SubMenuProps> = props => {
               {btn.name}
             </Button>
           ))}
+          {props.extras}
         </div>
       </Row>
       {props.children}

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -79,6 +79,9 @@ import { QueryObjectColumns } from 'src/views/CRUD/types';
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestSoftDeletedCell from '@pinterest-plugins/src/governance/softDeletion/pinterestSoftDeletedCell';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestChartListExtras } from '@pinterest-plugins/src/features/listView/pinterestListViewExtras';
 
 const FlexRowContainer = styled.div`
   align-items: center;
@@ -811,7 +814,11 @@ function ChartList(props: ChartListProps) {
 
   return (
     <>
-      <SubMenu name={t('Charts')} buttons={subMenuButtons} />
+      <SubMenu
+        name={t('Charts')}
+        buttons={subMenuButtons}
+        extras={getPinterestChartListExtras()}
+      />
       {sliceCurrentlyEditing && (
         <PropertiesModal
           onHide={closeChartEditModal}

--- a/superset-frontend/src/pages/DashboardList/index.tsx
+++ b/superset-frontend/src/pages/DashboardList/index.tsx
@@ -86,6 +86,9 @@ import {
   // @ts-ignore
   // eslint-disable-next-line import/no-unresolved
 } from '@pinterest-plugins/src/features/dashboards/dashboardListExtensions';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestDashboardListExtras } from '@pinterest-plugins/src/features/listView/pinterestListViewExtras';
 
 const PAGE_SIZE = 25;
 const PASSWORDS_NEEDED_MESSAGE = t(
@@ -786,7 +789,11 @@ function DashboardList(props: DashboardListProps) {
   }
   return (
     <>
-      <SubMenu name={t('Dashboards')} buttons={subMenuButtons} />
+      <SubMenu
+        name={t('Dashboards')}
+        buttons={subMenuButtons}
+        extras={getPinterestDashboardListExtras()}
+      />
       <ConfirmStatusChange
         title={t('Please confirm')}
         description={t(

--- a/superset-frontend/src/pages/DatasetList/index.tsx
+++ b/superset-frontend/src/pages/DatasetList/index.tsx
@@ -66,6 +66,9 @@ import DuplicateDatasetModal from 'src/features/datasets/DuplicateDatasetModal';
 import { useSelector } from 'react-redux';
 import { ModifiedInfo } from 'src/components/AuditInfo';
 import { QueryObjectColumns } from 'src/views/CRUD/types';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { getPinterestDatasetListExtras } from '@pinterest-plugins/src/features/listView/pinterestListViewExtras';
 
 const extensionsRegistry = getExtensionsRegistry();
 const DatasetDeleteRelatedExtension = extensionsRegistry.get(
@@ -650,6 +653,7 @@ const DatasetList: FunctionComponent<DatasetListProps> = ({
   }
 
   menuData.buttons = buttonArr;
+  menuData.extras = getPinterestDatasetListExtras();
 
   const closeDatasetDeleteModal = () => {
     setDatasetCurrentlyDeleting(null);

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -258,6 +258,20 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/dashboard\/pinterestDashboardHeaderExtras$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/dashboard/pinterestDashboardHeaderExtras.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/features\/listView\/pinterestListViewExtras$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/features/listView/pinterestListViewExtras.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/governance\/pinterestPushToDataHubModal$/,
       path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary

### Problem (Why)

We want to add additional UI to the dashboard header & list page submenu.
`SubMenu.buttons` only accepts plain `Button` props, so list pages can't host
split buttons, popovers, or other custom right-rail UI from a forked build.
The dashboard header likewise has no plugin slot.

### Solution (What + How)

- **`SubMenu.extras`:** new optional `extras?: ReactNode` prop on
  `SubMenuProps`, rendered after the existing buttons in `.nav-right`.
  No visual change when omitted.
- **Dashboard header:** wire `getPinterestDashboardHeaderExtras` into the
  header's right rail (gated on `!isEmbedded`); stub returns `<></>`. Added
  `dashboardInfo.id` and `isEmbedded` to the surrounding `useMemo` deps.
- **List pages** (`DashboardList`, `ChartList`, `DatasetList`): each page
  imports `getPinterest{Resource}ListExtras` and passes the node to
  `<SubMenu extras={…} />`. Stubs return `<></>`.
- **Stubs + build config:** new stub files under
  `superset-frontend/pinterest-plugins/...`; matching entries in
  `webpack.config.js` (`NormalModuleReplacementPlugin`) and `jest.config.js`
  (`moduleNameMapper`).
- Minor formatting tidy in `ListView/Filters/index.tsx`.

No behavioral change for the upstream build — stubs render nothing, and the
only public-API change is one new optional prop on `SubMenu`.

## Test Plan
Tested locally