### PR TITLE
feat(governance): Add governance items to chart title panels

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -86,6 +86,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/governance/pinterestVerifyChartModal.stub.tsx',
     '^@pinterest-plugins/src/governance/chartGovernancePermissions$':
       '<rootDir>/pinterest-plugins/src/governance/chartGovernancePermissions.stub.ts',
+    '^@pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems$':
+      '<rootDir>/pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx',
     // general mapping for other @pinterest-plugins modules
     '^@pinterest-plugins/(.*)$': '<rootDir>/pinterest-plugins/$1',
   },

--- a/superset-frontend/pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx
@@ -1,0 +1,9 @@
+type PinterestChartTitlePanelAdditionalItemsProps = {
+  sliceId?: number | null;
+};
+
+const PinterestChartTitlePanelAdditionalItems = (
+  _props: PinterestChartTitlePanelAdditionalItemsProps,
+) => null;
+
+export default PinterestChartTitlePanelAdditionalItems;

--- a/superset-frontend/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/src/components/PageHeaderWithActions/index.tsx
@@ -55,7 +55,8 @@ const headerStyles = (theme: SupersetTheme) => css`
   flex-wrap: nowrap;
   justify-content: space-between;
   background-color: ${theme.colors.grayscale.light5};
-  height: ${theme.gridUnit * 16}px;
+  /* height: ${theme.gridUnit * 16}px; */
+  min-height: ${theme.gridUnit * 16}px;
   padding: 0 ${theme.gridUnit * 4}px;
 
   .editable-title {
@@ -92,6 +93,9 @@ const buttonsStyles = (theme: SupersetTheme) => css`
   display: flex;
   align-items: center;
   padding-left: ${theme.gridUnit * 2}px;
+
+  margin-top: ${theme.gridUnit * 2}px;
+  margin-bottom: ${theme.gridUnit * 2}px;
 
   & .fave-unfave-icon {
     padding: 0 ${theme.gridUnit}px;

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -274,7 +274,9 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
             />
           </Tooltip>
           {!editMode && slice?.slice_id ? (
-            <PinterestChartTitlePanelAdditionalItems sliceId={slice?.slice_id} />
+            <PinterestChartTitlePanelAdditionalItems
+              sliceId={slice?.slice_id}
+            />
           ) : null}
           {!!Object.values(annotationQuery).length && (
             <Tooltip

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -36,6 +36,9 @@ import Icons from 'src/components/Icons';
 import { RootState } from 'src/dashboard/types';
 import { getSliceHeaderTooltip } from 'src/dashboard/util/getSliceHeaderTooltip';
 import { DashboardPageIdContext } from 'src/dashboard/containers/DashboardPage';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestChartTitlePanelAdditionalItems from '@pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -77,12 +80,65 @@ const ChartHeaderStyles = styled.div`
       text-overflow: ellipsis;
       max-width: 100%;
       flex-grow: 1;
+
+      /*
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
+      */
+
+      min-width: 0;
 
       & > span.antd5-tooltip-open {
-        display: inline;
+        /* display: inline; */
+        display: inline-flex;
+      }
+
+      .editable-title {
+        display: inline-flex;
+        flex: 0 1 auto;
+        align-items: center;
+        min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
+      }
+
+      .editable-title > a,
+      .editable-title > span {
+        display: -webkit-box;
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+        white-space: normal;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+
+      .editable-title > input,
+      .editable-title > textarea {
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+      }
+
+      .pinterest-chart-title-panel-additional-items {
+        display: flex;
+        flex: 0 1 auto;
+        width: 100%;
+        margin-left: 0;
+        max-width: 100%;
+        font-weight: ${theme.typography.weights.normal};
+
+        .ant-tag,
+        a {
+          font-weight: ${theme.typography.weights.normal};
+        }
+      }
+
+      .fa.warning,
+      .fa.danger {
+        flex: 0 0 auto;
+        margin-left: ${theme.gridUnit}px;
       }
     }
 
@@ -90,6 +146,7 @@ const ChartHeaderStyles = styled.div`
       display: flex;
       align-items: center;
       height: 24px;
+      flex: 0 0 auto;
 
       & > * {
         margin-left: ${theme.gridUnit * 2}px;
@@ -216,6 +273,9 @@ const SliceHeader = forwardRef<HTMLDivElement, SliceHeaderProps>(
               url={canExplore ? exploreUrl : undefined}
             />
           </Tooltip>
+          {!editMode && slice?.slice_id ? (
+            <PinterestChartTitlePanelAdditionalItems sliceId={slice?.slice_id} />
+          ) : null}
           {!!Object.values(annotationQuery).length && (
             <Tooltip
               id="annotations-loading-tooltip"

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -77,8 +77,8 @@ const additionalItemsStyles = theme => css`
   display: flex;
   /* align-items: center; */
   margin-left: ${theme.gridUnit}px;
-  
-  /* 
+
+  /*
   & > span {
     margin-right: ${theme.gridUnit * 3}px;
   }

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -37,6 +37,9 @@ import { getPinterestChartHeaderExtras } from '@pinterest-plugins/src/dashboard/
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestVerifyChartModal from '@pinterest-plugins/src/governance/pinterestVerifyChartModal';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestChartTitlePanelAdditionalItems from '@pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems';
 import { useExploreAdditionalActionsMenu } from '../useExploreAdditionalActionsMenu';
 import { useExploreMetadataBar } from './useExploreMetadataBar';
 
@@ -72,9 +75,27 @@ const saveButtonStyles = theme => css`
 
 const additionalItemsStyles = theme => css`
   display: flex;
-  align-items: center;
+  /* align-items: center; */
   margin-left: ${theme.gridUnit}px;
+  
+  /* 
   & > span {
+    margin-right: ${theme.gridUnit * 3}px;
+  }
+  */
+
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${theme.gridUnit}px;
+
+  .metadata-row,
+  .pinterest-additional-items-row {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .metadata-row > span {
     margin-right: ${theme.gridUnit * 3}px;
   }
 `;
@@ -215,17 +236,26 @@ export const ExploreChartHeader = ({
         }}
         titlePanelAdditionalItems={
           <div css={additionalItemsStyles}>
-            {sliceFormData ? (
-              <AlteredSliceTag
-                className="altered"
-                origFormData={{
-                  ...sliceFormData,
-                  chartTitle: oldSliceName,
-                }}
-                currentFormData={{ ...formData, chartTitle: sliceName }}
-              />
+            <div className="metadata-row">
+              {sliceFormData ? (
+                <AlteredSliceTag
+                  className="altered"
+                  origFormData={{
+                    ...sliceFormData,
+                    chartTitle: oldSliceName,
+                  }}
+                  currentFormData={{ ...formData, chartTitle: sliceName }}
+                />
+              ) : null}
+              {metadataBar}
+            </div>
+            {slice?.slice_id ? (
+              <div className="pinterest-additional-items-row">
+                <PinterestChartTitlePanelAdditionalItems
+                  sliceId={slice.slice_id}
+                />
+              </div>
             ) : null}
-            {metadataBar}
           </div>
         }
         rightPanelAdditionalItems={

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -434,7 +434,6 @@ const config = {
     },
   },
   optimization: {
-    minimize: !isDevMode,
     sideEffects: true,
     splitChunks: {
       chunks: 'all',
@@ -489,7 +488,7 @@ const config = {
       },
     },
     usedExports: 'global',
-    minimizer: isDevMode ? [] : [new CssMinimizerPlugin(), '...'],
+    minimizer: [new CssMinimizerPlugin(), '...'],
   },
   resolve: {
     // resolve modules from `/superset_frontend/node_modules` and `/superset_frontend`

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -335,6 +335,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/pinterestChartTitlePanelAdditionalItems$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/governance\/chartGovernancePermissions$/,
       path.resolve(
         __dirname,
@@ -427,6 +434,7 @@ const config = {
     },
   },
   optimization: {
+    minimize: !isDevMode,
     sideEffects: true,
     splitChunks: {
       chunks: 'all',
@@ -481,7 +489,7 @@ const config = {
       },
     },
     usedExports: 'global',
-    minimizer: [new CssMinimizerPlugin(), '...'],
+    minimizer: isDevMode ? [] : [new CssMinimizerPlugin(), '...'],
   },
   resolve: {
     // resolve modules from `/superset_frontend/node_modules` and `/superset_frontend`


### PR DESCRIPTION
### Summary
- Adds a Pinterest governance extension point to chart title panels in Explore and dashboard views.
- Updates title/header layout so metadata and governance items wrap cleanly without truncating chart actions.
- Adds stub module resolution for OSS

### Test plan
- Verify Explore chart headers render metadata items correctly.
- Verify dashboard slice headers renders correctly outside edit mode.