### PR TITLE
feat(governance): Stub batch chart gov properties

### DIFF
--- a/superset-frontend/pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems.stub.tsx
@@ -2,8 +2,17 @@ type PinterestChartTitlePanelAdditionalItemsProps = {
   sliceId?: number | null;
 };
 
+type UsePrefetchChartGovernanceParams = {
+  sliceIds: number[];
+  enabled?: boolean;
+};
+
 const PinterestChartTitlePanelAdditionalItems = (
   _props: PinterestChartTitlePanelAdditionalItemsProps,
 ) => null;
+
+export const usePrefetchChartGovernance = (
+  _params: UsePrefetchChartGovernanceParams,
+): void => {};
 
 export default PinterestChartTitlePanelAdditionalItems;

--- a/superset-frontend/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/src/components/PageHeaderWithActions/index.tsx
@@ -78,9 +78,26 @@ const headerStyles = (theme: SupersetTheme) => css`
 
   .title-panel {
     display: flex;
-    align-items: center;
+    /* align-items: center; */
     min-width: 0;
     margin-right: ${theme.gridUnit * 12}px;
+    margin-top: ${theme.gridUnit * 2}px;
+    margin-bottom: ${theme.gridUnit * 2}px;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .title-panel-content {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .title-additional-items {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    margin-top: ${theme.gridUnit}px;
   }
 
   .right-button-panel {
@@ -93,9 +110,6 @@ const buttonsStyles = (theme: SupersetTheme) => css`
   display: flex;
   align-items: center;
   padding-left: ${theme.gridUnit * 2}px;
-
-  margin-top: ${theme.gridUnit * 2}px;
-  margin-bottom: ${theme.gridUnit * 2}px;
 
   & .fave-unfave-icon {
     padding: 0 ${theme.gridUnit}px;
@@ -117,6 +131,7 @@ export type PageHeaderWithActionsProps = {
   showFaveStar: boolean;
   showMenuDropdown?: boolean;
   faveStarProps: FaveStarProps;
+  titleAdditionalItems?: ReactNode;
   titlePanelAdditionalItems: ReactNode;
   rightPanelAdditionalItems: ReactNode;
   additionalActionsMenu: ReactElement;
@@ -133,6 +148,7 @@ export const PageHeaderWithActions = ({
   certificatiedBadgeProps,
   showFaveStar,
   faveStarProps,
+  titleAdditionalItems,
   titlePanelAdditionalItems,
   rightPanelAdditionalItems,
   additionalActionsMenu,
@@ -144,15 +160,20 @@ export const PageHeaderWithActions = ({
   return (
     <div css={headerStyles} className="header-with-actions">
       <div className="title-panel">
-        <DynamicEditableTitle {...editableTitleProps} />
-        {showTitlePanelItems && (
-          <div css={buttonsStyles}>
-            {certificatiedBadgeProps?.certifiedBy && (
-              <CertifiedBadge {...certificatiedBadgeProps} />
-            )}
-            {showFaveStar && <FaveStar {...faveStarProps} />}
-            {titlePanelAdditionalItems}
-          </div>
+        <div className="title-panel-content">
+          <DynamicEditableTitle {...editableTitleProps} />
+          {showTitlePanelItems && (
+            <div css={buttonsStyles}>
+              {certificatiedBadgeProps?.certifiedBy && (
+                <CertifiedBadge {...certificatiedBadgeProps} />
+              )}
+              {showFaveStar && <FaveStar {...faveStarProps} />}
+              {titlePanelAdditionalItems}
+            </div>
+          )}
+        </div>
+        {titleAdditionalItems && (
+          <div className="title-additional-items">{titleAdditionalItems}</div>
         )}
       </div>
       <div className="right-button-panel">

--- a/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeaderControls/index.tsx
@@ -56,6 +56,12 @@ import { MenuKeys, RootState } from 'src/dashboard/types';
 import DrillDetailModal from 'src/components/Chart/DrillDetail/DrillDetailModal';
 import { usePermissions } from 'src/hooks/usePermissions';
 import ViewTableInfoModal from 'src/explore/components/controls/ViewTableInfoModal';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { canVerifyChart } from '@pinterest-plugins/src/governance/chartGovernancePermissions';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestVerifyChartModal from '@pinterest-plugins/src/governance/pinterestVerifyChartModal';
 import { useCrossFiltersScopingModal } from '../nativeFilters/FilterBar/CrossFilters/ScopingModal/useCrossFiltersScopingModal';
 import { ViewResultsModalTrigger } from './ViewResultsModalTrigger';
 
@@ -159,6 +165,7 @@ const SliceHeaderControls = (
   props: SliceHeaderControlsPropsWithRouter | SliceHeaderControlsProps,
 ) => {
   const [drillModalIsOpen, setDrillModalIsOpen] = useState(false);
+  const [isVerifyChartModalOpen, setIsVerifyChartModalOpen] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   // setting openKeys undefined falls back to uncontrolled behaviour
   const [openKeys, setOpenKeys] = useState<string[] | undefined>(undefined);
@@ -183,6 +190,10 @@ const SliceHeaderControls = (
       ?.behaviors?.includes(Behavior.InteractiveChart);
   const canExplore = props.supersetCanExplore;
   const { canDrillToDetail, canViewQuery, canViewTable } = usePermissions();
+  const user = useSelector<RootState, RootState['user']>(state => state.user);
+  const showVerifyChartAction =
+    isFeatureEnabled(FeatureFlag.PinterestChartGovernanceUi) &&
+    canVerifyChart(user);
   const refreshChart = () => {
     if (props.updatedDttm) {
       props.forceRefresh(props.slice.slice_id, props.dashboardId);
@@ -280,6 +291,10 @@ const SliceHeaderControls = (
         if (queryMenuRef.current && !queryMenuRef.current.showModal) {
           queryMenuRef.current.open(domEvent);
         }
+        break;
+      }
+      case MenuKeys.VerifyChart: {
+        setIsVerifyChartModalOpen(true);
         break;
       }
       default:
@@ -532,6 +547,10 @@ const SliceHeaderControls = (
           </Menu.Item>
         </Menu.SubMenu>
       )}
+
+      {showVerifyChartAction && (
+        <Menu.Item key={MenuKeys.VerifyChart}>{t('Verify Chart')}</Menu.Item>
+      )}
     </Menu>
   );
 
@@ -578,6 +597,14 @@ const SliceHeaderControls = (
       />
 
       {canEditCrossFilters && scopingModal}
+      {isVerifyChartModalOpen && slice?.slice_id != null && (
+        <PinterestVerifyChartModal
+          sliceId={slice.slice_id}
+          show={isVerifyChartModalOpen}
+          onHide={() => setIsVerifyChartModalOpen(false)}
+          user={user}
+        />
+      )}
     </>
   );
 };

--- a/superset-frontend/src/dashboard/containers/DashboardPage.tsx
+++ b/superset-frontend/src/dashboard/containers/DashboardPage.tsx
@@ -20,6 +20,9 @@ import { createContext, lazy, FC, useEffect, useMemo, useRef } from 'react';
 import { Global } from '@emotion/react';
 import { useHistory } from 'react-router-dom';
 import { t, useTheme } from '@superset-ui/core';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import { usePrefetchChartGovernance } from '@pinterest-plugins/src/governance/pinterestChartTitlePanelAdditionalItems';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from '@reduxjs/toolkit';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
@@ -132,6 +135,13 @@ export const DashboardPage: FC<PageProps> = ({ idOrSlug }: PageProps) => {
   const error = dashboardApiError || chartsApiError;
   const readyToRender = Boolean(dashboard && charts);
   const { dashboard_title, css, id = 0 } = dashboard || {};
+
+  // Prefetch chart governance data for all slices in the dashboard
+  const sliceIds = useSelector(selectAllSliceIds);
+  usePrefetchChartGovernance({
+    sliceIds,
+    enabled: readyToRender && Boolean(hasDashboardInfoInitiated),
+  });
 
   useEffect(() => {
     // mark tab id as redundant when user closes browser tab - a new id will be

--- a/superset-frontend/src/dashboard/types.ts
+++ b/superset-frontend/src/dashboard/types.ts
@@ -285,6 +285,7 @@ export enum MenuKeys {
   ManageEmbedded = 'manage_embedded',
   ManageEmailReports = 'manage_email_reports',
   ViewTableInfo = 'view_table_info',
+  VerifyChart = 'verify_chart',
   PinterestTieringInfo = 'pinterest_tiering_info',
   PinterestPromoteTier1 = 'pinterest_promote_tier1',
   PushToPinterestDataHub = 'push_to_pinterest_data_hub',

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.jsx
@@ -75,27 +75,9 @@ const saveButtonStyles = theme => css`
 
 const additionalItemsStyles = theme => css`
   display: flex;
-  /* align-items: center; */
+  align-items: center;
   margin-left: ${theme.gridUnit}px;
-
-  /*
   & > span {
-    margin-right: ${theme.gridUnit * 3}px;
-  }
-  */
-
-  flex-direction: column;
-  align-items: flex-start;
-  gap: ${theme.gridUnit}px;
-
-  .metadata-row,
-  .pinterest-additional-items-row {
-    display: flex;
-    align-items: center;
-    min-width: 0;
-  }
-
-  .metadata-row > span {
     margin-right: ${theme.gridUnit * 3}px;
   }
 `;
@@ -234,28 +216,24 @@ export const ExploreChartHeader = ({
           isStarred,
           showTooltip: true,
         }}
+        titleAdditionalItems={
+          slice?.slice_id ? (
+            <PinterestChartTitlePanelAdditionalItems sliceId={slice.slice_id} />
+          ) : null
+        }
         titlePanelAdditionalItems={
           <div css={additionalItemsStyles}>
-            <div className="metadata-row">
-              {sliceFormData ? (
-                <AlteredSliceTag
-                  className="altered"
-                  origFormData={{
-                    ...sliceFormData,
-                    chartTitle: oldSliceName,
-                  }}
-                  currentFormData={{ ...formData, chartTitle: sliceName }}
-                />
-              ) : null}
-              {metadataBar}
-            </div>
-            {slice?.slice_id ? (
-              <div className="pinterest-additional-items-row">
-                <PinterestChartTitlePanelAdditionalItems
-                  sliceId={slice.slice_id}
-                />
-              </div>
+            {sliceFormData ? (
+              <AlteredSliceTag
+                className="altered"
+                origFormData={{
+                  ...sliceFormData,
+                  chartTitle: oldSliceName,
+                }}
+                currentFormData={{ ...formData, chartTitle: sliceName }}
+              />
             ) : null}
+            {metadataBar}
           </div>
         }
         rightPanelAdditionalItems={


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
- Adds dashboard support for chart governance actions by prefetching governance data for dashboard slices and exposing the `Verify Chart` action in the slice header menu.
- Moves Pinterest chart title panel items into a dedicated title row in the Explore header, keeping certification/favorite/metadata items grouped beside the title.
- Update stubs so governance prefetch and title panel integrations 

### TESTING INSTRUCTIONS
- Manually confirm that eligible users see `Verify Chart` in dashboard slice actions.
- Manually confirm that clicking `Verify Chart` opens the modal for the selected chart.
- Manually confirm Explore header title metadata still renders correctly.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
