### PR TITLE
feat(charts): allow on-demand cache_screenshot/screenshot without enabling THUMBNAILS

### DIFF
--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -110,7 +110,13 @@ class ChartRestApi(BaseSupersetModelRestApi):
     resource_name = "chart"
     allow_browser_login = True
 
-    @before_request(only=["thumbnail", "screenshot", "cache_screenshot"])
+    # [pinterest-specific] Only gate the `thumbnail` endpoint behind the
+    # THUMBNAILS feature flag. `cache_screenshot` and `screenshot` are left
+    # ungated so the on-demand "cache screenshot" button works and the cached
+    # image is retrievable, without enabling the UI behaviors that
+    # `THUMBNAILS=True` would turn on (auto-loading thumbnails on the home page,
+    # in chart/dashboard card views, etc.).
+    @before_request(only=["thumbnail"])
     def ensure_thumbnails_enabled(self) -> Optional[Response]:
         if not is_feature_enabled("THUMBNAILS"):
             return self.response_404()


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Narrow the `@before_request` gate in `ChartRestApi` so only `thumbnail` is
404'd when `FEATURE_FLAGS["THUMBNAILS"]` is off. `cache_screenshot` and
`screenshot` are now reachable regardless of the flag. Mirrors the existing
Pinterest carve-out in `superset/dashboards/api.py`.

Why not just set `THUMBNAILS=True`:
- Thumbnail feature loads all charts/dashboards on list pages by default to show thumbnail view, adding a lot of load to our servers & db
- only allow screenshot endpoints to manually load screenshots as needed.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
