### PR TITLE
feat(governance): move dashboard governance tags to header second row

### DIFF
--- a/superset-frontend/jest.config.js
+++ b/superset-frontend/jest.config.js
@@ -50,6 +50,8 @@ module.exports = {
       '<rootDir>/pinterest-plugins/src/governance/pinterestNewDashboardTierModal.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestTitlePanelAdditionalItems$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestTitlePanelAdditionalItems.stub.tsx',
+    '^@pinterest-plugins/src/governance/pinterestDashboardSecondRowTags$':
+      '<rootDir>/pinterest-plugins/src/governance/pinterestDashboardSecondRowTags.stub.tsx',
     '^@pinterest-plugins/src/governance/pinterestDashboardBanners$':
       '<rootDir>/pinterest-plugins/src/governance/pinterestDashboardBanners.stub.tsx',
     '^@pinterest-plugins/src/explore/components/warden/createWardenAlertModal$':

--- a/superset-frontend/pinterest-plugins/src/governance/pinterestDashboardSecondRowTags.stub.tsx
+++ b/superset-frontend/pinterest-plugins/src/governance/pinterestDashboardSecondRowTags.stub.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+type PinterestDashboardSecondRowTagsProps = {
+  dashboardId: number;
+};
+
+/**
+ * Stub for the Pinterest dashboard header second-row governance tags
+ * (tier, Nimbus, Slack). Replaced by the real component when
+ * USE_PINTEREST_PLUGINS=true.
+ */
+const PinterestDashboardSecondRowTags = (
+  _props: PinterestDashboardSecondRowTagsProps,
+): ReactNode => null;
+
+export default PinterestDashboardSecondRowTags;

--- a/superset-frontend/src/components/PageHeaderWithActions/index.tsx
+++ b/superset-frontend/src/components/PageHeaderWithActions/index.tsx
@@ -48,13 +48,25 @@ export const menuTriggerStyles = (theme: SupersetTheme) => css`
   }
 `;
 
+const pageHeaderContainerStyles = (theme: SupersetTheme) => css`
+  display: flex;
+  flex-direction: column;
+  background-color: ${theme.colors.grayscale.light5};
+`;
+
+const secondRowStyles = css`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+`;
+
 const headerStyles = (theme: SupersetTheme) => css`
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-wrap: nowrap;
   justify-content: space-between;
-  background-color: ${theme.colors.grayscale.light5};
   /* height: ${theme.gridUnit * 16}px; */
   min-height: ${theme.gridUnit * 16}px;
   padding: 0 ${theme.gridUnit * 4}px;
@@ -80,6 +92,7 @@ const headerStyles = (theme: SupersetTheme) => css`
     display: flex;
     /* align-items: center; */
     min-width: 0;
+    overflow: hidden;
     margin-right: ${theme.gridUnit * 12}px;
     margin-top: ${theme.gridUnit * 2}px;
     margin-bottom: ${theme.gridUnit * 2}px;
@@ -103,12 +116,15 @@ const headerStyles = (theme: SupersetTheme) => css`
   .right-button-panel {
     display: flex;
     align-items: center;
+    flex-shrink: 0;
   }
 `;
 
 const buttonsStyles = (theme: SupersetTheme) => css`
   display: flex;
   align-items: center;
+  min-width: 0;
+  overflow: hidden;
   padding-left: ${theme.gridUnit * 2}px;
 
   & .fave-unfave-icon {
@@ -134,6 +150,7 @@ export type PageHeaderWithActionsProps = {
   titleAdditionalItems?: ReactNode;
   titlePanelAdditionalItems: ReactNode;
   rightPanelAdditionalItems: ReactNode;
+  headerSecondRow?: ReactNode;
   additionalActionsMenu: ReactElement;
   menuDropdownProps: Omit<AntdDropdownProps, 'overlay'>;
   tooltipProps?: {
@@ -151,6 +168,7 @@ export const PageHeaderWithActions = ({
   titleAdditionalItems,
   titlePanelAdditionalItems,
   rightPanelAdditionalItems,
+  headerSecondRow,
   additionalActionsMenu,
   menuDropdownProps,
   showMenuDropdown = true,
@@ -158,50 +176,57 @@ export const PageHeaderWithActions = ({
 }: PageHeaderWithActionsProps) => {
   const theme = useTheme();
   return (
-    <div css={headerStyles} className="header-with-actions">
-      <div className="title-panel">
-        <div className="title-panel-content">
-          <DynamicEditableTitle {...editableTitleProps} />
-          {showTitlePanelItems && (
-            <div css={buttonsStyles}>
-              {certificatiedBadgeProps?.certifiedBy && (
-                <CertifiedBadge {...certificatiedBadgeProps} />
-              )}
-              {showFaveStar && <FaveStar {...faveStarProps} />}
-              {titlePanelAdditionalItems}
-            </div>
+    <div css={pageHeaderContainerStyles} className="header-with-actions">
+      <div css={headerStyles}>
+        <div className="title-panel">
+          <div className="title-panel-content">
+            <DynamicEditableTitle {...editableTitleProps} />
+            {showTitlePanelItems && (
+              <div css={buttonsStyles}>
+                {certificatiedBadgeProps?.certifiedBy && (
+                  <CertifiedBadge {...certificatiedBadgeProps} />
+                )}
+                {showFaveStar && <FaveStar {...faveStarProps} />}
+                {titlePanelAdditionalItems}
+              </div>
+            )}
+          </div>
+          {titleAdditionalItems && (
+            <div className="title-additional-items">{titleAdditionalItems}</div>
           )}
         </div>
-        {titleAdditionalItems && (
-          <div className="title-additional-items">{titleAdditionalItems}</div>
-        )}
-      </div>
-      <div className="right-button-panel">
-        {rightPanelAdditionalItems}
-        <div css={additionalActionsContainerStyles}>
-          {showMenuDropdown && (
-            <AntdDropdown
-              trigger={['click']}
-              overlay={additionalActionsMenu}
-              {...menuDropdownProps}
-            >
-              <Button
-                css={menuTriggerStyles}
-                buttonStyle="tertiary"
-                aria-label={t('Menu actions trigger')}
-                tooltip={tooltipProps?.text}
-                placement={tooltipProps?.placement}
-                data-test="actions-trigger"
+        <div className="right-button-panel">
+          {rightPanelAdditionalItems}
+          <div css={additionalActionsContainerStyles}>
+            {showMenuDropdown && (
+              <AntdDropdown
+                trigger={['click']}
+                overlay={additionalActionsMenu}
+                {...menuDropdownProps}
               >
-                <Icons.MoreHoriz
-                  iconColor={theme.colors.primary.dark2}
-                  iconSize="l"
-                />
-              </Button>
-            </AntdDropdown>
-          )}
+                <Button
+                  css={menuTriggerStyles}
+                  buttonStyle="tertiary"
+                  aria-label={t('Menu actions trigger')}
+                  tooltip={tooltipProps?.text}
+                  placement={tooltipProps?.placement}
+                  data-test="actions-trigger"
+                >
+                  <Icons.MoreHoriz
+                    iconColor={theme.colors.primary.dark2}
+                    iconSize="l"
+                  />
+                </Button>
+              </AntdDropdown>
+            )}
+          </div>
         </div>
       </div>
+      {headerSecondRow && (
+        <div css={secondRowStyles} className="header-second-row">
+          {headerSecondRow}
+        </div>
+      )}
     </div>
   );
 };

--- a/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder/DashboardBuilder.tsx
@@ -109,6 +109,10 @@ const StyledHeader = styled.div`
     top: 0;
     z-index: 99;
     max-width: 100vw;
+    /* allow the header to shrink instead of expanding the 1fr grid track
+       (which otherwise pushes the dashboard body sideways when the filter
+       bar is open) */
+    min-width: 0;
 
     .empty-droptarget:before {
       position: absolute;
@@ -130,6 +134,7 @@ const StyledContent = styled.div<{
 }>`
   grid-column: 2;
   grid-row: 2;
+  min-width: 0;
   // @z-index-above-dashboard-header (100) + 1 = 101
   ${({ fullSizeChartId }) => fullSizeChartId && `z-index: 101;`}
 `;

--- a/superset-frontend/src/dashboard/components/Header/index.jsx
+++ b/superset-frontend/src/dashboard/components/Header/index.jsx
@@ -72,6 +72,9 @@ import PinterestTitlePanelAdditionalItems from '@pinterest-plugins/src/governanc
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
 import PinterestDashboardBanners from '@pinterest-plugins/src/governance/pinterestDashboardBanners';
+// @ts-ignore
+// eslint-disable-next-line import/no-unresolved
+import PinterestDashboardSecondRowTags from '@pinterest-plugins/src/governance/pinterestDashboardSecondRowTags';
 
 // @ts-ignore
 // eslint-disable-next-line import/no-unresolved
@@ -917,6 +920,11 @@ const Header = () => {
         faveStarProps={faveStarProps}
         titlePanelAdditionalItems={titlePanelAdditionalItems}
         rightPanelAdditionalItems={rightPanelAdditionalItems}
+        headerSecondRow={
+          !editMode && !isEmbedded && governanceUiEnabled ? (
+            <PinterestDashboardSecondRowTags dashboardId={dashboardInfo.id} />
+          ) : null
+        }
         menuDropdownProps={menuDropdownProps}
         additionalActionsMenu={additionalActionsMenu}
         showFaveStar={user?.userId && dashboardInfo?.id}

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -216,6 +216,13 @@ if (process.env.USE_PINTEREST_PLUGINS !== 'true') {
       ),
     ),
     new webpack.NormalModuleReplacementPlugin(
+      /@pinterest-plugins\/src\/governance\/pinterestDashboardSecondRowTags$/,
+      path.resolve(
+        __dirname,
+        'pinterest-plugins/src/governance/pinterestDashboardSecondRowTags.stub.tsx',
+      ),
+    ),
+    new webpack.NormalModuleReplacementPlugin(
       /@pinterest-plugins\/src\/governance\/pinterestDashboardBanners$/,
       path.resolve(
         __dirname,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**Context**
Dashboard title panel additional items were rendered inline in the main title panel alongside the dashboard title and action buttons. On narrow viewports — especially with the filter bar open — they competed with the title for horizontal space, caused overflow, and pushed the dashboard body sideways.

**Solution**
Introduce a generic, optional second row in the shared `PageHeaderWithActions` component and use it to render additional header items on their own line, keeping only a few items in the title panel.
  - `PageHeaderWithActions` now accepts an optional `headerSecondRow` node and renders the header as a vertical container: row 1 (title + actions), optional row 2. Adds `min-width`/`overflow` handling so the title panel can shrink instead of overflowing.
  - `DashboardBuilder` gets `min-width: 0` on the sticky header and content grid tracks so the header shrinks rather than pushing the dashboard body sideways when the filter bar is open.
  - Wires the dashboard `Header` to pass `<PinterestDashboardSecondRowTags />`  into `headerSecondRow` (gated on governance UI), via a new `@pinterest-plugins/.../pinterestDashboardSecondRowTags` import seam, stub, webpack `NormalModuleReplacementPlugin` entry, and jest `moduleNameMapper`.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
