### PR TITLE
fix(charts): Update default chart list sort to use metric_grade

### DIFF
--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -133,8 +133,6 @@ export enum FilterOperator {
   DashboardIsTier1Candidate = 'dashboard_is_tier1_candidate',
   /** Governance: filter by metric name */
   MetricName = 'metric_name',
-  /** Governance: filter by metric tier */
-  MetricTier = 'metric_tier',
   /** Governance: filter by metric grade */
   MetricGrade = 'metric_grade',
   /** Governance: filter by chart verification status */

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -256,7 +256,7 @@ function ChartList(props: ChartListProps) {
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
   const initialSort = showGovernanceExtras
-    ? [{ id: 'metric_grade', desc: true }]
+    ? [{ id: 'metric_grade', desc: false }]
     : [{ id: 'changed_on_delta_humanized', desc: true }];
   const handleBulkChartExport = (chartsToExport: Chart[]) => {
     const ids = chartsToExport.map(({ id }) => id);

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -256,7 +256,7 @@ function ChartList(props: ChartListProps) {
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
   const initialSort = showGovernanceExtras
-    ? [{ id: 'metric_tier', desc: false }]
+    ? [{ id: 'metric_grade', desc: true }]
     : [{ id: 'changed_on_delta_humanized', desc: true }];
   const handleBulkChartExport = (chartsToExport: Chart[]) => {
     const ids = chartsToExport.map(({ id }) => id);


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update default sort order to use `metric_grade` and remove references to `metric_tier` in list view.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
