### PR TITLE
fix(anomaly-detection): omit algorithm from default payload for backward compatibility

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
@@ -32,10 +32,13 @@ export const anomalyDetectionOperator: PostProcessingFactory<
       return { operation: 'anomaly_detection', options };
     }
 
+    // Isolation Forest is the default. Emit the original pre-multi-algorithm
+    // payload shape (no `algorithm` key) so existing charts stay backward
+    // compatible with backends that predate algorithm selection. The new
+    // backend defaults to Isolation Forest when `algorithm` is absent.
     return {
       operation: 'anomaly_detection',
       options: {
-        algorithm,
         contamination_rate: parseFloat(
           formData.anomalyDetectionContaminationRate,
         ),

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/anomalyDetectionOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/anomalyDetectionOperator.test.ts
@@ -39,12 +39,13 @@ test('returns isolation forest anomaly_detection rule when enabled and x-axis ex
     anomalyDetectionWeeklySeasonality: true,
   };
 
-  // operator ignores queryObject
+  // operator ignores queryObject.
+  // Default Isolation Forest omits the `algorithm` key so the payload stays
+  // backward compatible with backends that predate algorithm selection.
   // @ts-ignore
   expect(anomalyDetectionOperator(formData, {})).toEqual({
     operation: 'anomaly_detection',
     options: {
-      algorithm: 'isolation_forest',
       contamination_rate: 0.1,
       detrend: true,
       yearly_seasonality: true,
@@ -55,7 +56,7 @@ test('returns isolation forest anomaly_detection rule when enabled and x-axis ex
   });
 });
 
-test('defaults to isolation forest when no algorithm is set', () => {
+test('omits algorithm from the default isolation forest payload', () => {
   getXAxisLabel.mockReturnValue(['__timestamp']);
 
   const formData = {
@@ -66,7 +67,7 @@ test('defaults to isolation forest when no algorithm is set', () => {
   // @ts-ignore
   const rule = anomalyDetectionOperator(formData, {});
   // @ts-ignore
-  expect(rule.options.algorithm).toEqual('isolation_forest');
+  expect(rule.options).not.toHaveProperty('algorithm');
 });
 
 test('returns z-score rule with threshold and sliding window when selected', () => {


### PR DESCRIPTION
## Summary

The multi-algorithm anomaly detection change (#332) unconditionally added an `algorithm` key to the `anomaly_detection` post-processing options — **including for the default Isolation Forest path**.

Backends that predate algorithm selection have a fixed signature:

```python
def anomaly_detection(df, contamination_rate, detrend=..., ..., index=None): ...
```

with no `algorithm` parameter and no `**kwargs`. Superset dispatches post-processing as `getattr(pandas_postprocessing, operation)(df, **options)`, so any `options` containing `algorithm` raises the following at **argument-binding time**, before any anomaly logic runs:

```
TypeError: anomaly_detection() got an unexpected keyword argument 'algorithm'
```

This crashes existing default (Isolation Forest) charts whenever the new frontend is served against an older backend/worker (deploy version skew).

## Fix

- Emit the original pre-multi-algorithm payload (**no `algorithm` key**) for the default Isolation Forest case. The new backend already defaults to Isolation Forest when `algorithm` is absent, so behavior is identical.
- Non-default algorithms (z-score) still send `algorithm` — they inherently require the new backend, so this is correct.

Net change: the default IF path no longer emits a redundant `algorithm` key; the z-score path is untouched.

## Test plan

- [x] Unit: `anomalyDetectionOperator.test.ts` updated — default IF payload asserts **no** `algorithm` key; z-score still includes it. All 6 operator tests pass.
- [x] Lint passes on operator + test.
- [x] End-to-end against a simulated **old backend** (signature with no `algorithm`, no `**kwargs`):
  - Default **Isolation Forest** → binds cleanly, chart renders (previously crashed). ✅
  - **Z-Score** → rejected with the exact `unexpected keyword argument 'algorithm'` (expected — old backends have no z-score code). ✅
- [x] Confirmed via backend logs that the default IF request reaches the backend with no `algorithm` kwarg, and the network payload omits it.

<img width="1728" height="961" alt="image" src="https://github.com/user-attachments/assets/7429871a-a0fb-4a4b-9847-a4beb17a984f" />

<img width="1728" height="963" alt="image" src="https://github.com/user-attachments/assets/b268b97d-3723-44a7-aa7c-831cc721eec5" />


Made with [Cursor](https://cursor.com)