### PR TITLE
feat(anomaly-detection): summary tooltip + click-to-open explanation modal

### DIFF
--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/EchartsTimeseries.tsx
@@ -26,6 +26,8 @@ import {
   getNumberFormatter,
   LegendState,
   ensureIsArray,
+  styled,
+  t,
 } from '@superset-ui/core';
 import type { ViewRootGroup } from 'echarts/types/src/util/types';
 import type GlobalModel from 'echarts/types/src/model/Global';
@@ -35,8 +37,90 @@ import Echart from '../components/Echart';
 import { TimeseriesChartTransformedProps } from './types';
 import { formatSeriesName } from '../utils/series';
 import { ExtraControls } from '../components/ExtraControls';
+import {
+  AnomalyExplanationDetail,
+  getAnomalyExplanationFromClick,
+} from '../utils/anomalyDetection';
 
 const TIMER_DURATION = 300;
+
+/* eslint-disable theme-colors/no-literal-colors --
+   translucent modal overlay and drop shadow have no dedicated theme token */
+const AnomalyExplanationBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 1030;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+`;
+
+const AnomalyExplanationCard = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+    max-width: 560px;
+    max-height: 70vh;
+    background: ${theme.colors.grayscale.light5};
+    color: ${theme.colors.grayscale.dark2};
+    border-radius: ${theme.gridUnit}px;
+    box-shadow: 0 ${theme.gridUnit}px ${theme.gridUnit * 6}px
+      rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+  `}
+`;
+/* eslint-enable theme-colors/no-literal-colors */
+
+const AnomalyExplanationHeader = styled.div`
+  ${({ theme }) => `
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: ${theme.gridUnit * 2}px;
+    padding: ${theme.gridUnit * 3}px ${theme.gridUnit * 4}px;
+    border-bottom: 1px solid ${theme.colors.grayscale.light2};
+  `}
+`;
+
+const AnomalyExplanationTitle = styled.div`
+  ${({ theme }) => `
+    font-weight: ${theme.typography.weights.bold};
+    color: ${theme.colors.error.base};
+    margin-bottom: ${theme.gridUnit}px;
+  `}
+`;
+
+const AnomalyExplanationMeta = styled.div`
+  ${({ theme }) => `
+    font-size: ${theme.typography.sizes.s}px;
+    color: ${theme.colors.grayscale.dark1};
+  `}
+`;
+
+const AnomalyExplanationClose = styled.button`
+  ${({ theme }) => `
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: ${theme.typography.sizes.xl}px;
+    line-height: 1;
+    color: ${theme.colors.grayscale.base};
+    padding: 0;
+  `}
+`;
+
+const AnomalyExplanationBody = styled.div`
+  ${({ theme }) => `
+    padding: ${theme.gridUnit * 3}px ${theme.gridUnit * 4}px;
+    overflow-y: auto;
+    white-space: pre-line;
+    word-break: break-word;
+    line-height: 1.5;
+    color: ${theme.colors.grayscale.dark2};
+  `}
+`;
 
 export default function EchartsTimeseries({
   formData,
@@ -66,10 +150,25 @@ export default function EchartsTimeseries({
   const clickTimer = useRef<ReturnType<typeof setTimeout>>();
   const extraControlRef = useRef<HTMLDivElement>(null);
   const [extraControlHeight, setExtraControlHeight] = useState(0);
+  const [anomalyDetail, setAnomalyDetail] =
+    useState<AnomalyExplanationDetail | null>(null);
   useEffect(() => {
     const updatedHeight = extraControlRef.current?.offsetHeight || 0;
     setExtraControlHeight(updatedHeight);
   }, [formData.showExtraControls]);
+
+  useEffect(() => {
+    if (!anomalyDetail) {
+      return undefined;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setAnomalyDetail(null);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [anomalyDetail]);
 
   const hasDimensions = ensureIsArray(groupby).length > 0;
 
@@ -142,6 +241,17 @@ export default function EchartsTimeseries({
 
   const eventHandlers: EventHandlers = {
     click: props => {
+      // Clicking an anomaly point opens the full explanation in a modal. This
+      // is handled before the cross-filter logic (and works even without
+      // dimensions) so it also applies to charts without a groupby.
+      const anomaly = getAnomalyExplanationFromClick(props);
+      if (anomaly) {
+        if (clickTimer.current) {
+          clearTimeout(clickTimer.current);
+        }
+        setAnomalyDetail(anomaly);
+        return;
+      }
       if (!hasDimensions) {
         return;
       }
@@ -277,6 +387,45 @@ export default function EchartsTimeseries({
         zrEventHandlers={zrEventHandlers}
         selectedValues={selectedValues}
       />
+      {anomalyDetail && (
+        <AnomalyExplanationBackdrop
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('Anomaly explanation')}
+          onClick={() => setAnomalyDetail(null)}
+        >
+          <AnomalyExplanationCard onClick={e => e.stopPropagation()}>
+            <AnomalyExplanationHeader>
+              <div>
+                <AnomalyExplanationTitle>
+                  🚨 {t('Anomaly explanation')}
+                </AnomalyExplanationTitle>
+                <AnomalyExplanationMeta>
+                  {anomalyDetail.seriesName}
+                  {typeof anomalyDetail.score === 'number'
+                    ? ` · ${t('score')} ${anomalyDetail.score.toFixed(3)}`
+                    : ''}
+                  {typeof anomalyDetail.xValue === 'number'
+                    ? ` · ${xValueFormatter(anomalyDetail.xValue)}`
+                    : anomalyDetail.xValue
+                      ? ` · ${anomalyDetail.xValue}`
+                      : ''}
+                </AnomalyExplanationMeta>
+              </div>
+              <AnomalyExplanationClose
+                type="button"
+                onClick={() => setAnomalyDetail(null)}
+                aria-label={t('Close')}
+              >
+                ×
+              </AnomalyExplanationClose>
+            </AnomalyExplanationHeader>
+            <AnomalyExplanationBody>
+              {anomalyDetail.explanation}
+            </AnomalyExplanationBody>
+          </AnomalyExplanationCard>
+        </AnomalyExplanationBackdrop>
+      )}
     </>
   );
 }

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -61,7 +61,7 @@ export function buildAnomalyExplanationBlock(
 
   // Only hint when there's a detailed breakdown behind the summary.
   const hint = hasDetail
-    ? `<div style="margin-top: 4px; font-style: italic; color: ${theme.colors.info.base};">Click the point for the full explanation</div>`
+    ? `<div style="margin-top: 4px; font-style: italic; color: ${theme.colors.info.base};">Click the anomaly point for full explanation</div>`
     : '';
 
   return `<div style="margin-top: 8px;"><strong>Explanation:</strong><div style="${EXPLANATION_CONTENT_STYLE}">${summary}</div>${hint}</div>`;

--- a/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/utils/anomalyDetection.ts
@@ -29,6 +29,81 @@ export const ANOMALY_POINT_CONFIG = {
 
 export const DEFAULT_ANOMALY_SCORE = 0.5;
 
+// suffix appended to an anomaly scatter series name; used to recognize anomaly
+// points on click and to derive the originating series name
+export const ANOMALY_SERIES_NAME_SUFFIX = ' - Anomalies';
+
+const EXPLANATION_CONTENT_STYLE =
+  'max-width: 260px; margin-top: 4px; white-space: pre-line; ' +
+  'word-break: break-word; line-height: 1.45;';
+
+// Returns the leading summary paragraph of a Warden explanation. Explanations
+// lead with a plain-language summary, followed by the detailed model breakdown
+// (paragraphs separated by blank lines). Splitting on the first blank line lets
+// the hover tooltip show only the summary while the full text stays intact for
+// the click-to-open modal.
+export function getAnomalyExplanationSummary(explanation: string): string {
+  return explanation.split(/\n\s*\n/)[0].trim();
+}
+
+// Builds the tooltip "Explanation" block. Hover tooltips are transient and
+// (with rich/axis tooltips) can't be reliably clicked into, so only the summary
+// is shown here and the full detailed explanation is surfaced on click via a
+// modal (see EchartsTimeseries).
+export function buildAnomalyExplanationBlock(
+  explanation: string,
+  theme: SupersetTheme,
+): string {
+  const summary = sanitizeHtml(getAnomalyExplanationSummary(explanation));
+  const hasDetail =
+    explanation.trim().length >
+    getAnomalyExplanationSummary(explanation).length;
+
+  // Only hint when there's a detailed breakdown behind the summary.
+  const hint = hasDetail
+    ? `<div style="margin-top: 4px; font-style: italic; color: ${theme.colors.info.base};">Click the point for the full explanation</div>`
+    : '';
+
+  return `<div style="margin-top: 8px;"><strong>Explanation:</strong><div style="${EXPLANATION_CONTENT_STYLE}">${summary}</div>${hint}</div>`;
+}
+
+export interface AnomalyExplanationDetail {
+  // originating series (with the " - Anomalies" suffix stripped)
+  seriesName: string;
+  explanation: string;
+  score?: number;
+  xValue?: string | number;
+}
+
+// Given ECharts click event params, returns the anomaly explanation detail if
+// the click landed on an anomaly scatter point that carries an explanation, or
+// null otherwise. Kept here (not in the component) so it stays unit-testable.
+export function getAnomalyExplanationFromClick(
+  params: any,
+): AnomalyExplanationDetail | null {
+  const seriesName = String(params?.seriesName ?? '');
+  if (!seriesName.endsWith(ANOMALY_SERIES_NAME_SUFFIX)) {
+    return null;
+  }
+  const explanation = params?.data?.anomalyExplanation;
+  if (typeof explanation !== 'string' || explanation.length === 0) {
+    return null;
+  }
+  const value = params?.data?.value;
+  return {
+    seriesName: seriesName.slice(
+      0,
+      seriesName.length - ANOMALY_SERIES_NAME_SUFFIX.length,
+    ),
+    explanation,
+    score:
+      typeof params?.data?.anomalyScore === 'number'
+        ? params.data.anomalyScore
+        : undefined,
+    xValue: Array.isArray(value) ? value[0] : undefined,
+  };
+}
+
 // the following two functions dynamically adjust the color and size
 // of each anomaly point based on its anomaly score, which we expect to
 // have already been normalized to between 0 and 1
@@ -174,7 +249,7 @@ export function createAnomalyScatterSeries(
   });
 
   return {
-    name: `${seriesName} - Anomalies`,
+    name: `${seriesName}${ANOMALY_SERIES_NAME_SUFFIX}`,
     type: 'scatter',
     data: anomalyData,
     symbol: ANOMALY_POINT_CONFIG.symbol,
@@ -194,9 +269,7 @@ export function createAnomalyScatterSeries(
         const explanationBlock =
           typeof anomalyExplanation === 'string' &&
           anomalyExplanation.length > 0
-            ? `<div style="margin-top: 8px;"><strong>Explanation:</strong><div style="max-width: 260px; margin-top: 4px; white-space: pre-line; word-break: break-word; line-height: 1.45;">${sanitizeHtml(
-                anomalyExplanation,
-              )}</div></div>`
+            ? buildAnomalyExplanationBlock(anomalyExplanation, theme)
             : '';
 
         return `

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
@@ -6,6 +6,10 @@ import {
   createAnomalyLookup,
   createAnomalyScatterSeries,
   processAnomaliesForChart,
+  getAnomalyExplanationSummary,
+  buildAnomalyExplanationBlock,
+  getAnomalyExplanationFromClick,
+  ANOMALY_SERIES_NAME_SUFFIX,
 } from '../../src/utils/anomalyDetection';
 import type { RawSeriesEntry, AnomalyLookup, Refs } from '../../src/types';
 
@@ -319,6 +323,95 @@ describe('anomalyDetection utils', () => {
       expect(scatterSeries).toHaveLength(2);
       expect(scatterSeries[0].name).toBe('metric1 - Anomalies');
       expect(scatterSeries[1].name).toBe('metric2 - Anomalies');
+    });
+  });
+
+  describe('getAnomalyExplanationSummary', () => {
+    it('returns the leading paragraph before the first blank line', () => {
+      const summary = 'Short summary sentence.';
+      const detail = 'Detailed model breakdown.\n\nMore detail.';
+      expect(getAnomalyExplanationSummary(`${summary}\n\n${detail}`)).toBe(
+        summary,
+      );
+    });
+
+    it('returns the whole string when there is only one paragraph', () => {
+      const text = 'Just a summary, no detail.';
+      expect(getAnomalyExplanationSummary(text)).toBe(text);
+    });
+  });
+
+  describe('buildAnomalyExplanationBlock', () => {
+    it('shows the summary with no hint when there is no detail', () => {
+      const text = 'This point is unusual.';
+      const html = buildAnomalyExplanationBlock(text, mockTheme);
+
+      expect(html).toContain(text);
+      expect(html).not.toContain('Click the point for the full explanation');
+    });
+
+    it('shows only the summary and hints to click for the full text', () => {
+      const summary = 'Short summary sentence.';
+      const detail = 'Detailed model breakdown line.';
+      const html = buildAnomalyExplanationBlock(
+        `${summary}\n\n${detail}`,
+        mockTheme,
+      );
+
+      // only the leading summary paragraph is shown as a preview...
+      expect(html).toContain(summary);
+      // ...the detailed breakdown is NOT rendered in the tooltip...
+      expect(html).not.toContain(detail);
+      // ...and a hint points the user to click for the full explanation
+      expect(html).toContain('Click the point for the full explanation');
+    });
+
+    it('HTML-escapes the explanation text', () => {
+      const html = buildAnomalyExplanationBlock(
+        '<script>alert(1)</script>',
+        mockTheme,
+      );
+
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('getAnomalyExplanationFromClick', () => {
+    it('returns detail when an anomaly point with an explanation is clicked', () => {
+      const detail = getAnomalyExplanationFromClick({
+        seriesName: `metric1${ANOMALY_SERIES_NAME_SUFFIX}`,
+        data: {
+          value: ['2025-01-02', 200],
+          anomalyScore: 0.83,
+          anomalyExplanation: 'Spike vs seasonal baseline',
+        },
+      });
+
+      expect(detail).toEqual({
+        seriesName: 'metric1',
+        explanation: 'Spike vs seasonal baseline',
+        score: 0.83,
+        xValue: '2025-01-02',
+      });
+    });
+
+    it('returns null for a non-anomaly series', () => {
+      expect(
+        getAnomalyExplanationFromClick({
+          seriesName: 'metric1',
+          data: { value: ['2025-01-02', 200], anomalyExplanation: 'x' },
+        }),
+      ).toBeNull();
+    });
+
+    it('returns null when there is no explanation text', () => {
+      expect(
+        getAnomalyExplanationFromClick({
+          seriesName: `metric1${ANOMALY_SERIES_NAME_SUFFIX}`,
+          data: { value: ['2025-01-02', 200] },
+        }),
+      ).toBeNull();
     });
   });
 });

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
@@ -347,7 +347,7 @@ describe('anomalyDetection utils', () => {
       const html = buildAnomalyExplanationBlock(text, mockTheme);
 
       expect(html).toContain(text);
-      expect(html).not.toContain('Click the point for the full explanation');
+      expect(html).not.toContain('Click the anomaly point for full explanation');
     });
 
     it('shows only the summary and hints to click for the full text', () => {
@@ -363,7 +363,7 @@ describe('anomalyDetection utils', () => {
       // ...the detailed breakdown is NOT rendered in the tooltip...
       expect(html).not.toContain(detail);
       // ...and a hint points the user to click for the full explanation
-      expect(html).toContain('Click the point for the full explanation');
+      expect(html).toContain('Click the anomaly point for full explanation');
     });
 
     it('HTML-escapes the explanation text', () => {

--- a/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/utils/anomalyDetection.test.ts
@@ -347,7 +347,9 @@ describe('anomalyDetection utils', () => {
       const html = buildAnomalyExplanationBlock(text, mockTheme);
 
       expect(html).toContain(text);
-      expect(html).not.toContain('Click the anomaly point for full explanation');
+      expect(html).not.toContain(
+        'Click the anomaly point for full explanation',
+      );
     });
 
     it('shows only the summary and hints to click for the full text', () => {


### PR DESCRIPTION
## Summary
Anomaly explanations from Warden can be long, and hover tooltips are transient (and, with rich/axis tooltips, can't be reliably clicked into). This splits the presentation:

- **Hover tooltip** now shows only the leading plain-language **summary** paragraph plus an italic hint: _"Click the anomaly point for full explanation"_ (the hint only appears when there is more detail behind the summary).
- **Clicking an anomaly point** opens a modal with the **full detailed explanation**, plus the series name, anomaly score, and x-value. Closeable via the ×, click-outside, or the Escape key.

### Files
- `src/utils/anomalyDetection.ts`
  - `getAnomalyExplanationSummary` — leading paragraph (split on first blank line)
  - `buildAnomalyExplanationBlock` — tooltip HTML (summary + conditional hint, HTML-escaped)
  - `getAnomalyExplanationFromClick` — extracts anomaly detail from an ECharts click event
  - `ANOMALY_SERIES_NAME_SUFFIX` constant; `createAnomalyScatterSeries` uses it + the summary block
- `src/Timeseries/EchartsTimeseries.tsx` — click-to-open modal (styled components, `anomalyDetail` state, Escape-to-close), click handler routes anomaly-point clicks to the modal
- `test/utils/anomalyDetection.test.ts` — unit tests for the new helpers

## Test plan
- [x] `jest` unit tests for `getAnomalyExplanationSummary`, `buildAnomalyExplanationBlock`, `getAnomalyExplanationFromClick`
- [x] `tsc` build clean for plugin-chart-echarts
- [x] ESLint clean
- [x] Manual `make web`: hover shows summary + hint; clicking an anomaly opens modal with full explanation; ×/click-outside/Escape close it
<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 4 56 11 PM" src="https://github.com/user-attachments/assets/50a6d868-32a5-4bba-818f-614bff396239" />
<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 5 22 01 PM" src="https://github.com/user-attachments/assets/a23093e1-f4eb-4a74-ad97-bf2e31367556" />
<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 5 22 24 PM" src="https://github.com/user-attachments/assets/134b2d69-cbe2-40c9-9ea2-8232dc1dae1d" />

Made with [Cursor](https://cursor.com)