### PR TITLE
fix(ui): Restore frontend compatibility on Superset 6.0.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,19 +25,18 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
+
       - name: Setup Python
         uses: ./.github/actions/setup-backend/
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Enable brew and helm-docs
-        # Add brew to the path - see https://github.com/actions/runner-images/issues/6283
-        run: |
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          echo "HOMEBREW_PREFIX=$HOMEBREW_PREFIX" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_CELLAR=$HOMEBREW_CELLAR" >>"${GITHUB_ENV}"
-          echo "HOMEBREW_REPOSITORY=$HOMEBREW_REPOSITORY" >>"${GITHUB_ENV}"
-          brew install norwoodj/tap/helm-docs
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/anomalyDetectionOperator.ts
@@ -32,10 +32,13 @@ export const anomalyDetectionOperator: PostProcessingFactory<
       return { operation: 'anomaly_detection', options };
     }
 
+    // Isolation Forest is the default. Emit the original pre-multi-algorithm
+    // payload shape (no `algorithm` key) so existing charts stay backward
+    // compatible with backends that predate algorithm selection. The new
+    // backend defaults to Isolation Forest when `algorithm` is absent.
     return {
       operation: 'anomaly_detection',
       options: {
-        algorithm,
         contamination_rate: parseFloat(
           formData.anomalyDetectionContaminationRate,
         ),

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/anomalyDetectionOperator.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/anomalyDetectionOperator.test.ts
@@ -39,12 +39,13 @@ test('returns isolation forest anomaly_detection rule when enabled and x-axis ex
     anomalyDetectionWeeklySeasonality: true,
   };
 
-  // operator ignores queryObject
+  // operator ignores queryObject.
+  // Default Isolation Forest omits the `algorithm` key so the payload stays
+  // backward compatible with backends that predate algorithm selection.
   // @ts-ignore
   expect(anomalyDetectionOperator(formData, {})).toEqual({
     operation: 'anomaly_detection',
     options: {
-      algorithm: 'isolation_forest',
       contamination_rate: 0.1,
       detrend: true,
       yearly_seasonality: true,
@@ -55,7 +56,7 @@ test('returns isolation forest anomaly_detection rule when enabled and x-axis ex
   });
 });
 
-test('defaults to isolation forest when no algorithm is set', () => {
+test('omits algorithm from the default isolation forest payload', () => {
   getXAxisLabel.mockReturnValue(['__timestamp']);
 
   const formData = {
@@ -66,7 +67,7 @@ test('defaults to isolation forest when no algorithm is set', () => {
   // @ts-ignore
   const rule = anomalyDetectionOperator(formData, {});
   // @ts-ignore
-  expect(rule.options.algorithm).toEqual('isolation_forest');
+  expect(rule.options).not.toHaveProperty('algorithm');
 });
 
 test('returns z-score rule with threshold and sliding window when selected', () => {

--- a/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceAdvancedSearchModal/DatasourceAdvancedSearchModal.tsx
@@ -21,7 +21,7 @@ import DatasetTable from './DatasetTable';
 import FilterSidebar from './FilterSidebar';
 
 const StyledModal = styled(Modal)`
-  .antd5-modal-body {
+  .ant-modal-body {
     display: flex;
     flex-direction: row;
     padding: 0;

--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -140,8 +140,6 @@ export enum ListViewFilterOperator {
   DashboardIsTier1Candidate = 'dashboard_is_tier1_candidate',
   /** Governance: filter by metric name */
   MetricName = 'metric_name',
-  /** Governance: filter by metric tier */
-  MetricTier = 'metric_tier',
   /** Governance: filter by metric grade */
   MetricGrade = 'metric_grade',
   /** Governance: filter by chart verification status */

--- a/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
+++ b/superset-frontend/src/dashboard/components/SliceHeader/index.tsx
@@ -87,15 +87,60 @@ const ChartHeaderStyles = styled.div`
 
     & > .header-title {
       overflow: hidden;
-      text-overflow: ellipsis;
       max-width: calc(100% - ${theme.sizeUnit * 4}px);
       flex-grow: 1;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
+      min-width: 0;
+      display: flex;
+      align-items: flex-start;
 
       & > span.ant-tooltip-open {
-        display: inline;
+        display: inline-flex;
+      }
+
+      & > div:first-child {
+        min-width: 0;
+      }
+
+      .editable-title {
+        display: inline-flex;
+        flex: 0 1 auto;
+        align-items: center;
+        min-width: 0;
+        max-width: 100%;
+        overflow: hidden;
+      }
+
+      .editable-title > a,
+      .editable-title > span {
+        display: -webkit-box;
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+        white-space: normal;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+      }
+
+      .editable-title > input,
+      .editable-title > textarea {
+        overflow: hidden;
+        max-width: 100%;
+        text-overflow: ellipsis;
+      }
+
+      .pinterest-chart-title-panel-additional-items {
+        font-weight: ${theme.fontWeightNormal};
+
+        .ant-tag,
+        a {
+          font-weight: ${theme.fontWeightNormal};
+        }
+      }
+
+      .warning,
+      .danger {
+        flex: 0 0 auto;
+        margin-left: ${theme.sizeUnit}px;
       }
     }
 
@@ -103,6 +148,7 @@ const ChartHeaderStyles = styled.div`
       display: flex;
       align-items: center;
       height: 24px;
+      flex: 0 0 auto;
     }
 
     .dropdown.btn-group {

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -261,7 +261,7 @@ function ChartList(props: ChartListProps) {
   const canDelete = hasPerm('can_write');
   const canExport = hasPerm('can_export');
   const initialSort = showGovernanceExtras
-    ? [{ id: 'metric_tier', desc: false }]
+    ? [{ id: 'metric_grade', desc: false }]
     : [{ id: 'changed_on_delta_humanized', desc: true }];
   const handleBulkChartExport = (chartsToExport: Chart[]) => {
     const ids = chartsToExport.map(({ id }) => id);

--- a/superset-frontend/webpack.config.js
+++ b/superset-frontend/webpack.config.js
@@ -669,7 +669,11 @@ const config = {
       {
         test: /\.jsx?$/,
         // include source code for plugins, but exclude node_modules and test files within them
-        exclude: [/superset-ui.*\/node_modules\//, /\.test.jsx?$/],
+        exclude: [
+          /superset-ui.*\/node_modules\//,
+          /pinterest-plugins\/.*\/node_modules\//,
+          /\.test.jsx?$/,
+        ],
         include: [
           new RegExp(
             `${APP_DIR}/(src|.storybook|plugins|packages|pinterest-plugins)`,


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Restore Pinterest frontend behavior missed during the Superset 6 upgrade.
  - `2d9e3fe143` Fix governance chart sorting, chart-title layout
  - `bca9693e0a` Preserve anomaly-detection compatibility with older workers
- Exclude nested Pinterest plugin dependencies from Babel transpilation.
- Fix advanced dataset search styling


### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
