### PR TITLE
fix(query): Fix chart load issues post v6 migration

### DIFF
--- a/superset-frontend/src/dashboard/actions/dashboardState.js
+++ b/superset-frontend/src/dashboard/actions/dashboardState.js
@@ -602,13 +602,21 @@ export function onRefresh(
   force = false,
   interval = 0,
   dashboardId,
+  isLazyLoad = false,
 ) {
   return dispatch => {
-    dispatch({ type: ON_REFRESH });
+    // Only dispatch ON_REFRESH for dashboard-level refreshes
+    // Skip it for lazy-loaded tabs to prevent infinite loops
+    if (!isLazyLoad) {
+      dispatch({ type: ON_REFRESH });
+    }
+
     refreshCharts(chartList, force, interval, dashboardId, dispatch).then(
       () => {
         dispatch(onRefreshSuccess());
-        dispatch(onFiltersRefresh());
+        if (!isLazyLoad) {
+          dispatch(onFiltersRefresh());
+        }
       },
     );
   };

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Fragment, useCallback, memo, useEffect } from 'react';
+import { Fragment, useCallback, memo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
@@ -127,6 +127,9 @@ const Tab = props => {
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
 
+  // Track which refresh we've already handled to prevent duplicates
+  const handledRefreshRef = useRef(null);
+
   useEffect(() => {
     if (props.renderType === RENDER_TAB_CONTENT && props.isComponentVisible) {
       if (
@@ -134,13 +137,20 @@ const Tab = props => {
         tabActivationTime &&
         lastRefreshTime > tabActivationTime
       ) {
-        const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
-        if (chartIds.length > 0) {
-          requestAnimationFrame(() => {
+        // Create a unique key for this specific refresh
+        const refreshKey = `${props.id}-${lastRefreshTime}`;
+
+        // Only proceed if we haven't already handled this refresh
+        if (handledRefreshRef.current !== refreshKey) {
+          handledRefreshRef.current = refreshKey;
+
+          const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
+          if (chartIds.length > 0) {
+            // Use lazy load flag to avoid updating global refresh time
             setTimeout(() => {
-              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id));
+              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id, true));
             }, CHART_MOUNT_DELAY);
-          });
+          }
         }
       }
     }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Fragment, useCallback, memo, useEffect } from 'react';
+import { Fragment, useCallback, memo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { styled, t } from '@superset-ui/core';
 
 import { EditableTitle, EmptyState } from '@superset-ui/core/components';
-import { setEditMode, onRefresh } from 'src/dashboard/actions/dashboardState';
+import { setEditMode, fetchCharts } from 'src/dashboard/actions/dashboardState';
 import getChartIdsFromComponent from 'src/dashboard/util/getChartIdsFromComponent';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import AnchorLink from 'src/dashboard/components/AnchorLink';
@@ -126,19 +126,25 @@ const Tab = props => {
     state => state.dashboardState.tabActivationTimes?.[props.id] || 0,
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
+  const handledRefreshTimeRef = useRef(0);
 
   useEffect(() => {
     if (props.renderType === RENDER_TAB_CONTENT && props.isComponentVisible) {
       if (
         lastRefreshTime &&
         tabActivationTime &&
-        lastRefreshTime > tabActivationTime
+        lastRefreshTime > tabActivationTime &&
+        lastRefreshTime > handledRefreshTimeRef.current
       ) {
+        handledRefreshTimeRef.current = lastRefreshTime;
         const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
         if (chartIds.length > 0) {
           requestAnimationFrame(() => {
             setTimeout(() => {
-              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id));
+              // Dispatch fetchCharts rather than onRefresh: onRefresh sets
+              // lastRefreshTime, which this effect depends on, so it would
+              // re-trigger itself indefinitely.
+              dispatch(fetchCharts(chartIds, true, 0, dashboardInfo.id));
             }, CHART_MOUNT_DELAY);
           });
         }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.jsx
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Fragment, useCallback, memo, useEffect, useRef } from 'react';
+import { Fragment, useCallback, memo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useDispatch, useSelector } from 'react-redux';
 import { styled, t } from '@superset-ui/core';
 
 import { EditableTitle, EmptyState } from '@superset-ui/core/components';
-import { setEditMode, fetchCharts } from 'src/dashboard/actions/dashboardState';
+import { setEditMode, onRefresh } from 'src/dashboard/actions/dashboardState';
 import getChartIdsFromComponent from 'src/dashboard/util/getChartIdsFromComponent';
 import DashboardComponent from 'src/dashboard/containers/DashboardComponent';
 import AnchorLink from 'src/dashboard/components/AnchorLink';
@@ -126,25 +126,19 @@ const Tab = props => {
     state => state.dashboardState.tabActivationTimes?.[props.id] || 0,
   );
   const dashboardInfo = useSelector(state => state.dashboardInfo);
-  const handledRefreshTimeRef = useRef(0);
 
   useEffect(() => {
     if (props.renderType === RENDER_TAB_CONTENT && props.isComponentVisible) {
       if (
         lastRefreshTime &&
         tabActivationTime &&
-        lastRefreshTime > tabActivationTime &&
-        lastRefreshTime > handledRefreshTimeRef.current
+        lastRefreshTime > tabActivationTime
       ) {
-        handledRefreshTimeRef.current = lastRefreshTime;
         const chartIds = getChartIdsFromComponent(props.id, dashboardLayout);
         if (chartIds.length > 0) {
           requestAnimationFrame(() => {
             setTimeout(() => {
-              // Dispatch fetchCharts rather than onRefresh: onRefresh sets
-              // lastRefreshTime, which this effect depends on, so it would
-              // re-trigger itself indefinitely.
-              dispatch(fetchCharts(chartIds, true, 0, dashboardInfo.id));
+              dispatch(onRefresh(chartIds, true, 0, dashboardInfo.id));
             }, CHART_MOUNT_DELAY);
           });
         }

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -500,6 +500,7 @@ test('Should refresh charts when tab becomes active after dashboard refresh', as
     true, // Force refresh
     0, // Interval
     23, // Dashboard ID
+    true, // isLazyLoad flag
   );
 });
 
@@ -538,4 +539,106 @@ test('Should not refresh charts when tab becomes active if no dashboard refresh 
   await new Promise(resolve => setTimeout(resolve, 200));
 
   expect(onRefresh).not.toHaveBeenCalled();
+});
+
+test('Should not cause infinite refresh loop with nested tabs - regression test', async () => {
+  jest.clearAllMocks();
+  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
+  getChartIdsFromComponent.mockReset();
+  getChartIdsFromComponent.mockReturnValue([201, 202]);
+
+  const props = createProps();
+  props.renderType = 'RENDER_TAB_CONTENT';
+  props.isComponentVisible = false;
+
+  const initialState = {
+    dashboardState: {
+      lastRefreshTime: Date.now() - 1000, // Dashboard was refreshed recently
+      tabActivationTimes: {
+        'TAB-YT6eNksV-': Date.now() - 5000, // Tab was activated before refresh
+      },
+    },
+    dashboardInfo: {
+      id: 23,
+      dash_edit_perm: true,
+    },
+  };
+
+  const { rerender } = render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState,
+  });
+
+  // Initial state - no refresh should happen
+  expect(onRefresh).not.toHaveBeenCalled();
+
+  // Make tab visible - should trigger ONE refresh
+  rerender(<Tab {...props} isComponentVisible />);
+
+  await waitFor(
+    () => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    },
+    { timeout: 500 },
+  );
+
+  // Clear the mock to track subsequent calls
+  jest.clearAllMocks();
+
+  // REGRESSION TEST: Multiple re-renders should NOT trigger additional refreshes
+  // This simulates the infinite loop scenario that was happening with nested tabs
+  for (let i = 0; i < 5; i++) {
+    rerender(<Tab {...props} isComponentVisible />);
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+
+  expect(onRefresh).not.toHaveBeenCalled();
+});
+
+test('Should use isLazyLoad flag for tab refreshes', async () => {
+  jest.clearAllMocks();
+  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
+  getChartIdsFromComponent.mockReset();
+  getChartIdsFromComponent.mockReturnValue([401, 402]);
+
+  const props = createProps();
+  props.renderType = 'RENDER_TAB_CONTENT';
+  props.isComponentVisible = true;
+
+  const initialState = {
+    dashboardState: {
+      lastRefreshTime: Date.now() - 1000, // Dashboard was refreshed recently
+      tabActivationTimes: {
+        'TAB-YT6eNksV-': Date.now() - 5000, // Tab was activated before refresh
+      },
+    },
+    dashboardInfo: {
+      id: 42,
+      dash_edit_perm: true,
+    },
+  };
+
+  render(<Tab {...props} />, {
+    useRedux: true,
+    useDnd: true,
+    initialState,
+  });
+
+  // Tab should trigger refresh with isLazyLoad = true
+  await waitFor(
+    () => {
+      expect(onRefresh).toHaveBeenCalled();
+    },
+    { timeout: 500 },
+  );
+
+  // Verify that isLazyLoad flag is set to true for tab refreshes
+  expect(onRefresh).toHaveBeenCalledWith(
+    [401, 402],
+    true, // force
+    0, // interval
+    42, // dashboardId
+    true, // isLazyLoad should be true to prevent infinite loops
+  );
 });

--- a/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
+++ b/superset-frontend/src/dashboard/components/gridComponents/Tab/Tab.test.tsx
@@ -543,9 +543,8 @@ test('Should not refresh charts when tab becomes active if no dashboard refresh 
 
 test('Should not cause infinite refresh loop with nested tabs - regression test', async () => {
   jest.clearAllMocks();
-  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
-  getChartIdsFromComponent.mockReset();
-  getChartIdsFromComponent.mockReturnValue([201, 202]);
+  jest.mocked(getChartIdsFromComponent).mockReset();
+  jest.mocked(getChartIdsFromComponent).mockReturnValue([201, 202]);
 
   const props = createProps();
   props.renderType = 'RENDER_TAB_CONTENT';
@@ -588,19 +587,18 @@ test('Should not cause infinite refresh loop with nested tabs - regression test'
 
   // REGRESSION TEST: Multiple re-renders should NOT trigger additional refreshes
   // This simulates the infinite loop scenario that was happening with nested tabs
-  for (let i = 0; i < 5; i++) {
+  Array.from({ length: 5 }).forEach(() => {
     rerender(<Tab {...props} isComponentVisible />);
-    await new Promise(resolve => setTimeout(resolve, 20));
-  }
+  });
+  await new Promise(resolve => setTimeout(resolve, 100));
 
   expect(onRefresh).not.toHaveBeenCalled();
 });
 
 test('Should use isLazyLoad flag for tab refreshes', async () => {
   jest.clearAllMocks();
-  const getChartIdsFromComponent = require('src/dashboard/util/getChartIdsFromComponent');
-  getChartIdsFromComponent.mockReset();
-  getChartIdsFromComponent.mockReturnValue([401, 402]);
+  jest.mocked(getChartIdsFromComponent).mockReset();
+  jest.mocked(getChartIdsFromComponent).mockReturnValue([401, 402]);
 
   const props = createProps();
   props.renderType = 'RENDER_TAB_CONTENT';

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -356,11 +356,14 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                             )
                         ) from ex
                     engine = database.db_engine_spec.engine
+                    # The clause is only rendered here so that it can be parsed; the
+                    # context is partial, so the rendered SQL is not what will run.
                     sanitized_clause = sanitize_clause(rendered_clause, engine)
-                    # The clause is only rendered so that it can be parsed. A templated
-                    # clause has to be re-rendered when the query is built, where the
-                    # full Jinja context is available, so only a plain SQL clause can be
-                    # replaced with its sanitized form.
+                    # A templated clause is re-rendered and sanitized again when the
+                    # query is built, in `_process_sql_expression`, so replacing it
+                    # here would only discard the template. Only a plain SQL clause is
+                    # replaced with its sanitized form, which keeps the cache key
+                    # stable across formatting differences.
                     is_templated = any(
                         delimiter in clause for delimiter in ("{{", "{%", "{#")
                     )

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -347,7 +347,7 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                         time_grain=self.extras.get("time_grain_sqla"),
                     )
                     try:
-                        clause = processor.process_template(clause, force=True)
+                        rendered_clause = processor.process_template(clause, force=True)
                     except TemplateError as ex:
                         raise QueryObjectValidationError(
                             _(
@@ -356,8 +356,15 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
                             )
                         ) from ex
                     engine = database.db_engine_spec.engine
-                    sanitized_clause = sanitize_clause(clause, engine)
-                    if sanitized_clause != clause:
+                    sanitized_clause = sanitize_clause(rendered_clause, engine)
+                    # The clause is only rendered so that it can be parsed. A templated
+                    # clause has to be re-rendered when the query is built, where the
+                    # full Jinja context is available, so only a plain SQL clause can be
+                    # replaced with its sanitized form.
+                    is_templated = any(
+                        delimiter in clause for delimiter in ("{{", "{%", "{#")
+                    )
+                    if not is_templated and sanitized_clause != clause:
                         self.extras[param] = sanitized_clause
                 except QueryClauseValidationException as ex:
                     raise QueryObjectValidationError(ex.message) from ex

--- a/superset/common/query_object.py
+++ b/superset/common/query_object.py
@@ -342,7 +342,10 @@ class QueryObject:  # pylint: disable=too-many-instance-attributes
             if clause and self.datasource:
                 try:
                     database = self.datasource.database
-                    processor = get_template_processor(database=database)
+                    processor = get_template_processor(
+                        database=database,
+                        time_grain=self.extras.get("time_grain_sqla"),
+                    )
                     try:
                         clause = processor.process_template(clause, force=True)
                     except TemplateError as ex:


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes two chart-loading regressions introduced by the Superset 6 migration:
- an infinite refresh loop on dashboard tabs
- Jinja-templated WHERE/HAVING filters being silently stripped of their templates.

## Dashboard tabs refreshed forever
Cherry-picked PR [37018](https://github.com/apache/superset/pull/37018)

## Templated WHERE/HAVING clauses were being destroyed
`QueryObject._sanitize_filters` renders a filter clause to check it parses,
then normalizes it. It was assigning the rendered output back over the
original `clause` variable, so the comparison ran against post-render text and
the rendered, sanitized SQL got written into `extras`. Any Jinja in a WHERE or
HAVING filter was therefore replaced by a one-time render.
That render is deliberately minimal at validation time, so the baked-in result
was also wrong — it lacked the filters, URL params, and user context the real
query build supplies.
The render now goes into a separate `rendered_clause` used only for parsing,
and the normalized clause is written back only when the original contains no
Jinja delimiters. Templated clauses are left untouched and are re-rendered and
sanitized later in `_process_sql_expression` with the full context, so
validation strictness is unchanged.
Separately, the template processor is now given the query's `time_grain_sqla`
as `time_grain`, so `{{ time_grain }}` resolves during validation instead of
failing to parse.


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- force refresh dashboard, confirm that dashboards load
- view query in explore route, no longer see `null` date filters

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
