### PR TITLE
fix(charts): Fix stale requests overwriting chart state

### DIFF
--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -65,8 +65,8 @@ export function chartUpdateSucceeded(queriesResponse, key) {
 }
 
 export const CHART_UPDATE_STOPPED = 'CHART_UPDATE_STOPPED';
-export function chartUpdateStopped(key) {
-  return { type: CHART_UPDATE_STOPPED, key };
+export function chartUpdateStopped(key, queryController) {
+  return { type: CHART_UPDATE_STOPPED, key, queryController };
 }
 
 export const CHART_UPDATE_FAILED = 'CHART_UPDATE_FAILED';
@@ -456,6 +456,15 @@ export function exploreJSON(
         handleChartDataResponse(response, json, useLegacyApi),
       )
       .then(queriesResponse => {
+        // Drop stale responses: if a newer query has started for this chart,
+        // its controller will have replaced ours in state, so ignore this
+        // response to avoid clobbering newer data with older results.
+        if (key != null) {
+          const currentController = getState().charts?.[key]?.queryController;
+          if (currentController && currentController !== controller) {
+            return undefined;
+          }
+        }
         queriesResponse.forEach(resultItem =>
           dispatch(
             logEvent(LOG_ACTIONS_LOAD_CHART, {
@@ -497,9 +506,20 @@ export function exploreJSON(
           );
         };
 
-        if (response.name === 'AbortError') {
+        const isAbort =
+          response?.name === 'AbortError' || response?.statusText === 'abort';
+        if (isAbort) {
           appendErrorLog('abort');
-          return dispatch(chartUpdateStopped(key));
+          return dispatch(chartUpdateStopped(key, controller));
+        }
+
+        // Drop stale failures the same way we drop stale successes,
+        // so a slow earlier request can't mark a newer one as failed.
+        if (key != null) {
+          const currentController = getState().charts?.[key]?.queryController;
+          if (currentController && currentController !== controller) {
+            return undefined;
+          }
         }
 
         const logAndFail = (parsedResponse, overrideErrorDetails) => {

--- a/superset-frontend/src/components/Chart/chartActions.test.js
+++ b/superset-frontend/src/components/Chart/chartActions.test.js
@@ -110,6 +110,70 @@ describe('chart actions', () => {
       .callsFake(data => Promise.resolve(data));
   });
 
+  test('should drop stale success dispatches when a newer controller has replaced ours in state', async () => {
+    const chartKey = 'stale_success_test';
+    const formData = {
+      slice_id: 456,
+      datasource: 'table__1',
+      viz_type: 'table',
+    };
+    // A controller belonging to a newer in-flight request, already stored
+    // in state by the time this thunk's response resolves.
+    const newerController = new AbortController();
+    const state = {
+      charts: {
+        [chartKey]: {
+          queryController: newerController,
+        },
+      },
+      common: {
+        conf: {
+          SUPERSET_WEBSERVER_TIMEOUT: 60,
+        },
+      },
+    };
+    const getState = jest.fn(() => state);
+    const dispatchMock = jest.fn();
+    const getChartDataRequestSpy = jest
+      .spyOn(actions, 'getChartDataRequest')
+      .mockResolvedValue({
+        response: { status: 200 },
+        json: { result: [{ data: [{ stale: true }] }] },
+      });
+    const handleChartDataResponseSpy = jest
+      .spyOn(actions, 'handleChartDataResponse')
+      .mockResolvedValue([{ data: [{ stale: true }] }]);
+    const updateDataMaskSpy = jest
+      .spyOn(dataMaskActions, 'updateDataMask')
+      .mockReturnValue({ type: 'UPDATE_DATA_MASK' });
+    const getQuerySettingsStub = sinon
+      .stub(exploreUtils, 'getQuerySettings')
+      .returns([false, () => {}]);
+
+    try {
+      const thunkAction = actions.exploreJSON(
+        formData,
+        false,
+        undefined,
+        chartKey,
+      );
+      await thunkAction(dispatchMock, getState);
+
+      // CHART_UPDATE_STARTED is fine (it ran before the gate),
+      // but CHART_UPDATE_SUCCEEDED must not fire with stale data.
+      const dispatchedTypes = dispatchMock.mock.calls.map(
+        ([action]) => action?.type,
+      );
+      expect(dispatchedTypes).toContain(actions.CHART_UPDATE_STARTED);
+      expect(dispatchedTypes).not.toContain(actions.CHART_UPDATE_SUCCEEDED);
+    } finally {
+      getChartDataRequestSpy.mockRestore();
+      handleChartDataResponseSpy.mockRestore();
+      updateDataMaskSpy.mockRestore();
+      getQuerySettingsStub.restore();
+    }
+  });
+
   test('should defer abort of previous controller to avoid Redux state mutation', async () => {
     jest.useFakeTimers();
     const chartKey = 'defer_abort_test';

--- a/superset-frontend/src/components/Chart/chartReducer.ts
+++ b/superset-frontend/src/components/Chart/chartReducer.ts
@@ -78,11 +78,19 @@ export default function chartReducer(
       };
     },
     [actions.CHART_UPDATE_STOPPED](state) {
+      if (
+        action.queryController &&
+        state.queryController &&
+        action.queryController !== state.queryController
+      ) {
+        return state;
+      }
       return {
         ...state,
         chartStatus: 'stopped',
         chartAlert: t('Updating chart was stopped'),
         chartUpdateEndTime: now(),
+        queryController: null,
       };
     },
     [actions.CHART_RENDERING_SUCCEEDED](state) {

--- a/superset-frontend/src/components/Chart/chartReducers.test.js
+++ b/superset-frontend/src/components/Chart/chartReducers.test.js
@@ -32,9 +32,39 @@ describe('chart reducers', () => {
   });
 
   it('should update endtime on fail', () => {
-    const newState = chartReducer(charts, actions.chartUpdateStopped(chartKey));
+    const controller = new AbortController();
+    charts[chartKey] = {
+      ...charts[chartKey],
+      queryController: controller,
+    };
+    const newState = chartReducer(
+      charts,
+      actions.chartUpdateStopped(chartKey, controller),
+    );
     expect(newState[chartKey].chartUpdateEndTime).toBeGreaterThan(0);
     expect(newState[chartKey].chartStatus).toEqual('stopped');
+    expect(newState[chartKey].queryController).toBeNull();
+  });
+
+  it('should ignore stopped updates from stale controllers', () => {
+    const controller = new AbortController();
+    const staleController = new AbortController();
+    charts[chartKey] = {
+      ...charts[chartKey],
+      chartStatus: 'loading',
+      queryController: controller,
+    };
+
+    const newState = chartReducer(
+      charts,
+      actions.chartUpdateStopped(chartKey, staleController),
+    );
+
+    expect(newState[chartKey].chartStatus).toEqual('loading');
+    expect(newState[chartKey].chartUpdateEndTime).toEqual(
+      charts[chartKey].chartUpdateEndTime,
+    );
+    expect(newState[chartKey].queryController).toBe(controller);
   });
 
   it('should update endtime on timeout', () => {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
Some charts were not rendering, and charts that were previously rendered would re-render as empty when moving around a dashboard. Cherry picked relevant changes from [37459](https://github.com/apache/superset/pull/37459) and [40065](https://github.com/apache/superset/pull/40065)
- Ignore stale chart responses when a newer request is active
- Prevent aborted superseded requests from stopping the current chart load
- Clear request controllers after valid cancellations
- Add regression tests for stale responses and controllers. This fixes charts becoming blank or remaining unrendered after overlapping requests.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
