### PR TITLE
fix(echarts): restore dashed line style for time comparison series (#…

### DIFF
--- a/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/src/operators/utils/isDerivedSeries.ts
@@ -28,11 +28,16 @@ import { hasTimeOffset } from './timeOffset';
 export const isDerivedSeries = (
   series: JsonObject,
   formData: QueryFormData,
+  seriesName?: string,
 ): boolean => {
   const comparisonType = formData.comparison_type;
   if (comparisonType !== ComparisonType.Values) {
     return false;
   }
   const timeCompare: string[] = ensureIsArray(formData?.time_compare);
-  return hasTimeOffset(series, timeCompare);
+  // Check if series matches time offset patterns or exact match (single metric case)
+  return (
+    hasTimeOffset(series, timeCompare) ||
+    (seriesName !== undefined && timeCompare.includes(seriesName))
+  );
 };

--- a/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/isDerivedSeries.test.ts
+++ b/superset-frontend/packages/superset-ui-chart-controls/test/operators/utils/isDerivedSeries.test.ts
@@ -97,3 +97,24 @@ test('should be false if series name invalid', () => {
   };
   expect(isDerivedSeries(series, formDataWithActualTypes)).toEqual(false);
 });
+
+test('should be true for exact match when seriesName parameter is provided', () => {
+  const exactMatchSeries = {
+    id: '1 week ago',
+    name: '1 week ago',
+    data: [100],
+  };
+  const formDataWithTimeCompare = {
+    ...formData,
+    comparison_type: ComparisonType.Values,
+    time_compare: ['1 week ago'],
+  };
+  // Without seriesName parameter, exact match is not detected via hasTimeOffset
+  expect(isDerivedSeries(exactMatchSeries, formDataWithTimeCompare)).toEqual(
+    false,
+  );
+  // With seriesName parameter, exact match is detected
+  expect(
+    isDerivedSeries(exactMatchSeries, formDataWithTimeCompare, '1 week ago'),
+  ).toEqual(true);
+});

--- a/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/src/Timeseries/transformProps.ts
@@ -44,6 +44,7 @@ import {
 import {
   extractExtraMetrics,
   getOriginalSeries,
+  getTimeOffset,
   isDerivedSeries,
 } from '@superset-ui/chart-controls';
 import type { EChartsCoreOption } from 'echarts/core';
@@ -299,7 +300,7 @@ export default function transformProps(
   const array = ensureIsArray(chartProps.rawFormData?.time_compare);
   const inverted = invert(verboseMap);
 
-  let patternIncrement = 0;
+  const offsetLineWidths: { [key: string]: number } = {};
 
   const anomalyLookup: AnomalyLookup = createAnomalyLookup(
     rawSeries as RawSeriesEntry[],
@@ -307,28 +308,38 @@ export default function transformProps(
   );
 
   (rawSeries as RawSeriesEntry[]).forEach(entry => {
-    const derivedSeries = isDerivedSeries(entry, chartProps.rawFormData);
-    const lineStyle: LineStyleOption = {};
-    if (derivedSeries) {
-      patternIncrement += 1;
-      // use a combination of dash and dot for the line style
-      lineStyle.type = [(patternIncrement % 5) + 1, (patternIncrement % 3) + 1];
-      lineStyle.opacity = OpacityEnum.DerivedSeries;
-    }
-
     const entryName = String(entry.name || '');
     const seriesName = inverted[entryName] || entryName;
+    const derivedSeries = isDerivedSeries(
+      entry,
+      chartProps.rawFormData,
+      seriesName,
+    );
+    const lineStyle: LineStyleOption = {};
+    if (derivedSeries) {
+      const offset = getTimeOffset(entry, array) || seriesName;
+      if (!offsetLineWidths[offset]) {
+        offsetLineWidths[offset] = Object.keys(offsetLineWidths).length + 1;
+      }
+      const patternIndex = offsetLineWidths[offset];
+      lineStyle.type = [(patternIndex % 5) + 4, (patternIndex % 3) + 3];
+      lineStyle.opacity = OpacityEnum.DerivedSeries;
+    }
 
     let colorScaleKey = getOriginalSeries(seriesName, array);
 
     // If this series name exactly matches a time compare value, it's a time-shifted series
     // and we need to find the corresponding original series for color matching
-    if (array && array.includes(seriesName)) {
+    if (derivedSeries && array.includes(seriesName)) {
       // Find the original series (first non-time-compare series)
-      const originalSeries = rawSeries.find(s => {
-        const sName = inverted[String(s.name || '')] || String(s.name || '');
-        return !array.includes(sName);
-      });
+      const originalSeries = rawSeries.find(
+        s =>
+          !isDerivedSeries(
+            s,
+            chartProps.rawFormData,
+            inverted[String(s.name || '')] || String(s.name || ''),
+          ),
+      );
       if (originalSeries) {
         const originalSeriesName =
           inverted[String(originalSeries.name || '')] ||

--- a/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
+++ b/superset-frontend/plugins/plugin-chart-echarts/test/Timeseries/transformProps.test.ts
@@ -21,6 +21,7 @@ import {
   AnnotationStyle,
   AnnotationType,
   ChartProps,
+  ComparisonType,
   EventAnnotationLayer,
   FormulaAnnotationLayer,
   IntervalAnnotationLayer,
@@ -623,5 +624,51 @@ describe('Does transformProps transform series correctly', () => {
       'foo1, bar1': ['foo1', 'bar1'],
       'foo2, bar2': ['foo2', 'bar2'],
     });
+  });
+
+  it('should apply dashed line styles to single-metric time shifts', () => {
+    const chartProps = new ChartProps({
+      ...chartPropsConfig,
+      formData: {
+        ...formData,
+        groupby: [],
+        time_compare: ['1 year ago', '2 years ago'],
+        comparison_type: ComparisonType.Values,
+      },
+      queriesData: [
+        {
+          data: [
+            {
+              sum__num: 100,
+              '1 year ago': 80,
+              '2 years ago': 60,
+              __timestamp: 599616000000,
+            },
+          ],
+        },
+      ],
+    });
+    const transformedSeries = transformProps(
+      chartProps as unknown as EchartsTimeseriesChartProps,
+    ).echartOptions.series as unknown as {
+      name?: string;
+      lineStyle?: { type?: unknown };
+    }[];
+
+    const originalSeries = transformedSeries.find(
+      series => series.name === 'sum__num',
+    );
+    const shiftedSeries = transformedSeries.filter(series =>
+      ['1 year ago', '2 years ago'].includes(series.name ?? ''),
+    );
+
+    expect(originalSeries?.lineStyle?.type).toBeUndefined();
+    expect(shiftedSeries).toHaveLength(2);
+    shiftedSeries.forEach(series => {
+      expect(Array.isArray(series.lineStyle?.type)).toBe(true);
+    });
+    expect(shiftedSeries[0].lineStyle?.type).not.toEqual(
+      shiftedSeries[1].lineStyle?.type,
+    );
   });
 });


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After upgrading from v5.0.0 to v6.0.0, a regression with time shift series was found. The lines are supposed to be dashed instead of solid. Cherry-picked changes from [37135](https://github.com/apache/superset/pull/37135) to fix this.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
