### PR TITLE
fix(reports): capture chart error state and real dashboard element in…

### DIFF
--- a/superset-frontend/src/components/Chart/Chart.tsx
+++ b/superset-frontend/src/components/Chart/Chart.tsx
@@ -377,7 +377,11 @@ class Chart extends PureComponent<ChartProps, {}> {
 
     if (chartStatus === 'failed') {
       return (
-        <ErrorContainer height={height}>
+        <ErrorContainer
+          className="chart-container"
+          data-test="chart-container"
+          height={height}
+        >
           {queriesResponse?.map(item =>
             this.renderErrorMessage(item as ChartErrorType),
           )}

--- a/superset/utils/webdriver.py
+++ b/superset/utils/webdriver.py
@@ -600,14 +600,22 @@ class WebDriverSelenium(WebDriverProxy):
         logger.debug("Sleeping for %i seconds", selenium_headstart)
         sleep(selenium_headstart)
 
+        # "standalone" (used for dashboards) is a sentinel, not a real CSS class --
+        # a standalone dashboard renders its content under ".grid-container". Wait
+        # for that real element so a login/error page (which has neither the grid
+        # nor a chart) fails loudly instead of being silently captured, then
+        # screenshot the whole chrome-less standalone page.
+        capture_full_page = element_name == "standalone"
+        locate_class = "grid-container" if capture_full_page else element_name
+
         try:
             try:
                 # page didn't load
                 logger.debug(
-                    "Wait for the presence of %s at url: %s", element_name, url
+                    "Wait for the presence of %s at url: %s", locate_class, url
                 )
                 element = WebDriverWait(driver, self._screenshot_locate_wait).until(
-                    EC.presence_of_element_located((By.CLASS_NAME, element_name))
+                    EC.presence_of_element_located((By.CLASS_NAME, locate_class))
                 )
             except TimeoutException:
                 logger.warning(
@@ -684,7 +692,11 @@ class WebDriverSelenium(WebDriverProxy):
                         unexpected_errors,
                     )
 
-            img = element.screenshot_as_png
+            img = (
+                driver.get_screenshot_as_png()
+                if capture_full_page
+                else element.screenshot_as_png
+            )
         except TimeoutException:
             # Already logged at WARNING in the inner handlers above
             raise


### PR DESCRIPTION

  After the 6.1 upgrade, report/alert screenshots on the Selenium/Firefox engine failed with a geckodriver `NoSuchElementError ... dom.find/`. That string is misleading — it's the swallowed `NoSuchElementException` stacktrace that
  `WebDriverWait.until` attaches to the `TimeoutException` it raises when the element it's waiting on never appears within `SCREENSHOT_LOCATE_WAIT`.

  Two independent root causes:

  1. **Charts (`Chart.tsx`)** — In 6.1 the `chartStatus === 'failed'` branch renders its `ErrorContainer` (a plain `styled.div`) → `ChartErrorMessage`, neither of which carries `.chart-container`. In 6.0 the error state still had a
  `.chart-container`. So any chart that errors for the report user has no element for the screenshotter to find and the screenshot times out. Charts that render normally still succeed (why some reports sent and most didn't).
  2. **Dashboards (`webdriver.py`)** — `DashboardScreenshot.element = "standalone"` is a sentinel string, not a real CSS class; nothing in the DOM has `.standalone`. A standalone dashboard's real content wrapper is `.grid-container`.
  The Selenium `get_screenshot` waited for `.standalone`, so dashboard screenshots never had a valid locate target.

  Fixes:

  - **`Chart.tsx`**: add `className="chart-container"` (and `data-test`) to the failed-state `ErrorContainer`, restoring 6.0 behavior. An errored chart is now captured *as its error card*.
  - **`webdriver.py`**: map the dashboard sentinel to the real element — `locate_class = "grid-container" if element_name == "standalone" else element_name` — and screenshot the full (chrome-less) standalone page for dashboards, else
  the located element. The original **raise-on-timeout** behavior is preserved: a page with neither `.grid-container` nor `.chart-container` (e.g. a login page after a failed auth) fails the report loudly rather than shipping a
  misleading screenshot.

  ### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

  **Before:** chart reports fail with `Failed taking a screenshot ... NoSuchElementError ... dom.find/`; dashboard reports never locate content.

  **After:** errored charts render their error card in the screenshot; dashboards capture the standalone view.

  ### TESTING INSTRUCTIONS

  1. Rebuild frontend assets (the `Chart.tsx` change requires a webpack rebuild) and restart the worker so the `webdriver.py` change is loaded.
  2. **Chart report, error state:** point a chart at a query that errors for the report user, run the report → the delivered screenshot shows the chart error card instead of the report failing.
  3. **Chart report, happy path:** run a normal chart report → screenshot renders as before (no regression).
  4. **Dashboard report:** run a dashboard report → the standalone dashboard is captured (previously produced no valid element).
  5. **Negative case:** run a report where the screenshot user can't authenticate (lands on `/login/`) → the report is logged as ERROR and no screenshot is sent (fails loudly, no login-page image).
  6. **Regression:** `pytest tests/unit_tests/utils/webdriver_test.py`; `npm run test -- Chart.test.tsx`.

  ### ADDITIONAL INFORMATION

  - [ ] Has associated issue:
  - [ ] Required feature flags:
  - [x] Changes UI
  - [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Introduces new feature or API
  - [ ] Removes existing feature or API